### PR TITLE
Error color

### DIFF
--- a/docs/classes-and-components.md
+++ b/docs/classes-and-components.md
@@ -17,7 +17,7 @@ This will generate a `banano.json` file with all the current classes and compone
     require('@tailwindcss/forms'),
     require('@headlessui/tailwindcss'),
     banano.tailwindPlugin({
-      colors: ['orange'],
+      colors: ['lime'],
       components: require('./banano.json') // [!code ++]
     }),
   ],
@@ -31,7 +31,7 @@ This will generate a `banano.json` file with all the current classes and compone
     require('@tailwindcss/forms'),
     require('@headlessui/tailwindcss'),
     banano.tailwindPlugin({
-      colors: ['orange'],
+      colors: ['lime'],
       components: {
         BnInput: { // [!code ++]
           '.bn-input': { // [!code ++]

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -9,6 +9,7 @@ The colors are as follows:
 | banano&#x2011;text&#x2011;foreground | `tailwindColors.gray['900']`<br />(string) | Color used for regular texts inside inputs (regular, area, filet, etc.) |
 | banano&#x2011;text&#x2011;muted | `tailwindColors.gray['500']`<br />(string) | Color used for placeholder texts inside inputs (regular, area, filet, etc.) |
 | banano&#x2011;bg | `tailwindColors.white`<br />(string) | Color used for the background in inputs |
+| banano&#x2011;error | `tailwindColors.red['500']`<br />(string) | Color used for all error related style changes: texts, borders, focus rings, etc. For rings in particular, a 25% opacity of this color is used |
 
 A config that overrides these colors would look like this:
 
@@ -27,6 +28,7 @@ module.exports = {
             muted: tailwindColors.zinc['300'],
           },
           bg: tailwindColors.lime['50'],
+          error: tailwindColors.rose['500'],
         },
       },
     },

--- a/docs/components/bn-input.md
+++ b/docs/components/bn-input.md
@@ -84,16 +84,16 @@ Due to the way Tailwind compiles classes, to avoid generating CSS for every sing
 // tailwind.config.js
 {
 ...
-  require('banano').tailwindPlugin({ colors: ['orange']}),
+  require('banano').tailwindPlugin({ colors: ['lime']}),
 }
 ```
 
 ```html
-<bn-input name="input" color="orange" />
+<bn-input name="input" color="lime" />
 ```
 <code-preview>
   <div class="grid col-span-1 gap-4">
-    <bn-input name="input" color="orange" />
+    <bn-input name="input" color="lime" />
   </div>
 </code-preview>
 

--- a/src/components/BnCheckbox/BnCheckbox.story.vue
+++ b/src/components/BnCheckbox/BnCheckbox.story.vue
@@ -102,7 +102,7 @@ function isRequired(val: string) {
           v-model="state.single"
           name="color"
           value="Checked"
-          color="orange"
+          color="lime"
         >
           This is a checkbox
         </BnCheckbox>
@@ -115,7 +115,7 @@ function isRequired(val: string) {
           :rules="(isRequired as GenericValidateFunction)"
           name="color"
           value="Checked"
-          color="orange"
+          color="lime"
         >
           This is a checkbox
         </BnCheckbox>

--- a/src/components/BnCheckbox/BnCheckbox.styles.cjs
+++ b/src/components/BnCheckbox/BnCheckbox.styles.cjs
@@ -5,17 +5,16 @@ module.exports = {
       '@apply cursor-not-allowed opacity-75': {},
     },
     '&--error': {
-      '@apply text-red-500': {},
+      '@apply text-banano-error !important': {},
       '.bn-checkbox__input': {
-        '@apply border-red-500': {},
+        '@apply border-banano-error focus:ring-banano-error !important': {},
       },
     },
     '&__input': {
       '@apply mr-2 rounded border-gray-300': {},
       colors: {
         '@apply text-varColor-600': {},
-        '@apply focus:outline focus:outline-1 focus:outline-varColor-600': {},
-        '@apply focus:border-varColor-600 focus:ring-varColor-600': {},
+        '@apply focus:outline-none focus:border-varColor-600 focus:ring-2 focus:ring-varColor-600': {},
       },
     },
   },

--- a/src/components/BnCheckbox/BnCheckbox.styles.cjs
+++ b/src/components/BnCheckbox/BnCheckbox.styles.cjs
@@ -11,10 +11,11 @@ module.exports = {
       },
     },
     '&__input': {
-      '@apply mr-2 rounded border-gray-300': {},
+      '@apply mr-2 rounded border-gray-300 focus:outline-none focus:ring-0 focus:ring-offset-0': {},
+      '@apply focus-visible:ring-offset-2 focus-visible:ring-2': {},
       colors: {
         '@apply text-varColor-600': {},
-        '@apply focus:outline-none focus:border-varColor-600 focus:ring-2 focus:ring-varColor-600': {},
+        '@apply focus-visible:border-varColor-600 focus-visible:ring-varColor-600': {},
       },
     },
   },

--- a/src/components/BnFileInput/BnFileInput.styles.cjs
+++ b/src/components/BnFileInput/BnFileInput.styles.cjs
@@ -10,10 +10,7 @@ module.exports = {
       '@apply p-0 border-0 h-auto bg-banano-bg text-banano-text-foreground': {},
     },
     '&--error': {
-      '@apply border border-red-300 text-red-700 ring-red-300 outline-red-300 !important': {},
-      '.bn-file-input__placeholder': {
-        '@apply text-red-500': {},
-      },
+      '@apply border border-banano-error !important': {},
     },
     '&__input': {
       '@apply hidden': {},

--- a/src/components/BnInput/BnInput.story.vue
+++ b/src/components/BnInput/BnInput.story.vue
@@ -47,7 +47,7 @@ function isRequired(val: string) {
       <template #default>
         <BnInput
           v-model="state.value"
-          color="orange"
+          color="lime"
           name="placeholder"
         />
       </template>

--- a/src/components/BnInput/BnInput.styles.cjs
+++ b/src/components/BnInput/BnInput.styles.cjs
@@ -6,8 +6,7 @@ module.exports = {
       '@apply placeholder:text-banano-text-muted': {},
       '@apply disabled:bg-gray-100 disabled:opacity-75 disabled:cursor-not-allowed': {},
       colors: {
-        '@apply focus:outline focus:outline-1 focus:outline-varColor-600': {},
-        '@apply focus:border-varColor-600 focus:ring-varColor-600': {},
+        '@apply focus:outline-none focus:ring focus:border-varColor-600 focus:ring-varColor-600/25': {},
       },
       '&--icon-left': {
         '@apply pl-10': {},
@@ -22,7 +21,7 @@ module.exports = {
         '@apply rounded-r-none': {},
       },
       '&--error': {
-        '@apply border border-red-300 text-red-700 ring-red-300 outline-red-300 !important': {},
+        '@apply border-banano-error focus:ring-banano-error/25 !important': {},
       },
     },
     '&__icon-left': {

--- a/src/components/BnListbox/BnListbox.story.vue
+++ b/src/components/BnListbox/BnListbox.story.vue
@@ -92,7 +92,7 @@ function isRequired(val: string) {
           v-model="state.single"
           name="color"
           :options="selectOptions"
-          color="orange"
+          color="lime"
         />
       </template>
     </Variant>

--- a/src/components/BnListbox/BnListbox.styles.cjs
+++ b/src/components/BnListbox/BnListbox.styles.cjs
@@ -6,12 +6,13 @@ module.exports = {
     '&__button': {
       '@apply flex h-12 w-full items-center truncate rounded-lg border border-gray-200 p-3 bg-banano-bg': {},
       '@apply text-banano-text-foreground': {},
-      '@apply ui-open:outline ui-open:outline-1': {},
+      '@apply ui-open:outline-none focus:outline-none focus:ring ui-open:ring': {},
       '&--error': {
-        '@apply border border-red-300 text-red-700 ring-red-300 outline-red-300 !important': {},
+        '@apply border border-banano-error ring-banano-error/25 !important': {},
       },
       colors: {
-        '@apply ui-open:border-varColor-600 ui-open:outline-varColor-600 ui-open:ring-varColor-600': {},
+        '@apply ui-open:border-varColor-600 focus:border-varColor-600': {},
+        '@apply ui-open:ring-varColor-600/25 focus:ring-varColor-600/25': {},
       },
     },
     '&__tag': {

--- a/src/components/BnTextarea/BnTextarea.story.vue
+++ b/src/components/BnTextarea/BnTextarea.story.vue
@@ -35,7 +35,7 @@ function isRequired(val: string) {
         <BnTextarea
           v-model="state.value"
           name="color"
-          color="orange"
+          color="lime"
         />
       </template>
     </Variant>

--- a/src/components/BnTextarea/BnTextarea.styles.cjs
+++ b/src/components/BnTextarea/BnTextarea.styles.cjs
@@ -2,13 +2,13 @@ module.exports = {
   '.bn-textarea': {
     '@apply w-full': {},
     '@apply py-3 px-3 rounded-lg border border-gray-200 text-banano-text-foreground bg-banano-bg': {},
-    '@apply placeholder:text-banano-text-muted': {},
+    '@apply placeholder:text-banano-text-muted focus:outline-none focus:ring': {},
     '@apply disabled:bg-gray-100 disabled:opacity-75 disabled:cursor-not-allowed': {},
     colors: {
-      '@apply focus:border-varColor-600 focus:ring-varColor-600': {},
+      '@apply focus:border-varColor-600 focus:ring-varColor-600/25': {},
     },
     '&--error': {
-      '@apply border border-red-300 text-red-700 ring-red-300 !important': {},
+      '@apply border border-banano-error focus:ring-banano-error/25 !important': {},
     },
   },
 };

--- a/src/components/BnToggle/BnToggle.story.vue
+++ b/src/components/BnToggle/BnToggle.story.vue
@@ -102,7 +102,7 @@ function isRequired(val: string) {
           v-model="state.single"
           name="color"
           value="Checked"
-          color="orange"
+          color="lime"
         >
           This is a toggle
         </BnToggle>
@@ -115,7 +115,7 @@ function isRequired(val: string) {
           :rules="(isRequired as GenericValidateFunction)"
           name="color"
           value="Checked"
-          color="orange"
+          color="lime"
         >
           This is a toggle
         </BnToggle>

--- a/src/components/BnToggle/BnToggle.styles.cjs
+++ b/src/components/BnToggle/BnToggle.styles.cjs
@@ -5,9 +5,9 @@ module.exports = {
       '@apply cursor-not-allowed opacity-75': {},
     },
     '&--error': {
-      '@apply text-red-500': {},
+      '@apply text-banano-error': {},
       '.bn-toggle__input': {
-        '@apply border-red-500': {},
+        '@apply border-banano-error': {},
       },
     },
     '&__wrapper': {

--- a/src/components/BnToggle/BnToggle.styles.cjs
+++ b/src/components/BnToggle/BnToggle.styles.cjs
@@ -30,14 +30,9 @@ module.exports = {
           '@apply bg-varColor-500': {},
         },
       },
-      '&:focus ~ .bn-toggle__track': {
+      '&:focus-visible ~ .bn-toggle__track': {
         colors: {
-          '@apply ring-2 ring-offset-2 ring-varColor-500': {},
-        },
-      },
-      '&:active ~ .bn-toggle__track': {
-        colors: {
-          '@apply ring-2 ring-offset-2 ring-varColor-500': {},
+          '@apply ring-2 ring-offset-4 ring-varColor-500': {},
         },
       },
     },

--- a/src/components/Btn/Btn.story.vue
+++ b/src/components/Btn/Btn.story.vue
@@ -26,8 +26,8 @@ const variantVariants = [
 ];
 
 const colorVariants = [
-  { color: 'orange' },
-  { color: 'orange', variant: 'outline' },
+  { color: 'lime' },
+  { color: 'lime', variant: 'outline' },
 ];
 
 const loadingVariants = [

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.histoire-generic-render-story {
+  padding: .5rem;
+}

--- a/src/tailwind/index.cjs
+++ b/src/tailwind/index.cjs
@@ -44,20 +44,19 @@ function parseColors(classes, colors = {}) {
 function parseStyles(obj, colors, componentClass, elementClasses = []) {
   return Object.entries(obj).reduce((prev, [key, value]) => {
     const newElementClasses = [...elementClasses];
-    if (key !== 'colors') {
+    if (key === 'colors') {
+      const colorClasses = parseColors(value, colors);
+      const isElement = newElementClasses[1] && newElementClasses[1].startsWith('&__');
+      const newElementClass = newElementClasses.join('').replace(/&/g, '');
+
+      Object.keys(colorClasses).forEach((color) => {
+        prev[`@at-root ${componentClass}--${color}${isElement ? ' ' : ''}${newElementClass}`] = parseStyles(colorClasses[color], colors, componentClass, newElementClasses);
+      });
+    } else {
       if (!key.startsWith('@')) {
         newElementClasses.push(key);
       }
       prev[key] = parseStyles(value, colors, componentClass, newElementClasses);
-      const colorClasses = value.colors ? parseColors(value.colors, colors) : {};
-      if (colorClasses) {
-        const isElement = newElementClasses[1] && newElementClasses[1].startsWith('&__');
-        const newElementClass = newElementClasses.join('').replace(/&/g, '');
-
-        Object.keys(colorClasses).forEach((color) => {
-          prev[`@at-root ${componentClass}--${color}${isElement ? ' ' : ''}${newElementClass}`] = parseStyles(colorClasses[color], colors, componentClass, newElementClasses);
-        });
-      }
     }
 
     return prev;

--- a/src/tailwind/index.cjs
+++ b/src/tailwind/index.cjs
@@ -110,6 +110,7 @@ const themeColors = {
   'banano-text-foreground': tailwindColors.gray['900'],
   'banano-text-muted': tailwindColors.gray['500'],
   'banano-bg': tailwindColors.white,
+  'banano-error': tailwindColors.red['500'],
 };
 const defaultOptions = { colors: themeColors, components: {} };
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -12,6 +12,6 @@ module.exports = {
   plugins: [
     require('@tailwindcss/forms'),
     require('@headlessui/tailwindcss'),
-    banano.tailwindPlugin({ colors: ['orange'] }),
+    banano.tailwindPlugin({ colors: ['lime'] }),
   ],
 };


### PR DESCRIPTION
## Context
Currently, banano has a bunch of components with some customization options. Most of this components have some error state that comes with a few style changes

## Changes
This PR replaces all error styles that used the tailwind `red` family of colors to use a theme customizable `banano-error` color:

 - Added `banano-error` color to index.cjs theme extension
 - Use `banano-error` color in: `BnInput`, `BnCheckbox`, `BnFileInput`, `BnListbox`, `BnTextarea` and `BnToggle`
   - For rings, a 25% opacity version is used
   - I removed red color from input-like texts, following the Super Library Figma and a conversation with the design team
 - Updated color docs
 
**Extra**
- In changed components, made it so only `ring` was used, disabling `outline`
- Added padding to historie stories, to avoid box-shadow from being cut off, [following this suggestion](https://github.com/histoire-dev/histoire/issues/342#issuecomment-1312846903)
- Changed default example color to `lime`, as orange was too similar to red and made it difficult to differentiate
- In checkboxes and toggles, changed `focus` to `focus-visible` to avoid showing ring after clicking
- Fixed a bug that did not apply color specific styles when the `colors` key was in the first level of the styles object. Needed for textarea

## Images of focused elements with error

**BnInput**
![image](https://github.com/platanus/banano/assets/12057523/8339d725-a571-4d9c-97ad-d775ef5d149b)

**BnFileInput**
![image](https://github.com/platanus/banano/assets/12057523/aa6664b0-7b30-43db-9975-eae833253f95)

**BnInput**
![image](https://github.com/platanus/banano/assets/12057523/58b595cb-981a-439a-a5ed-6594befd0fbf)

**BnListbox**
![image](https://github.com/platanus/banano/assets/12057523/74b1e017-3b5f-488b-956c-a36be7b88a30)

**BnTextarea**
![image](https://github.com/platanus/banano/assets/12057523/392e04e5-8d70-4039-a2f7-a8e2b5bd57c8)

**BnToggle**
![image](https://github.com/platanus/banano/assets/12057523/2d943802-d907-4d8b-8f62-dae6dd65c0a0)