### PR TITLE
fix(vitepress): add theme customization index view

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -15,6 +15,7 @@ export default defineConfig({
             },
             {
               text: 'Theme Customization',
+              link: '/theme-customization',
               collapsed: false,
               items: [
                 {

--- a/docs/theme-customization.md
+++ b/docs/theme-customization.md
@@ -1,0 +1,4 @@
+# Theme Customization
+
+* [Classes and Components](#classes-and-components)
+* [Colors](#colors)


### PR DESCRIPTION
## Context
- Currently, banano has a bunch of components with some customization options
- In #2, some customizable tailwind colors were added, and with that a "Colors" section was added to the documentation
  - [The documentation deploy of this PR failed](https://github.com/platanus/banano/actions/runs/5049213281/jobs/9058372500) because of a dead link to the now missing Theme Customization page (it was changed to just be a collapsible item in the sidebar)

## Changes

This PR fixes the deploy by adding a Theme Configuration page that just acts like an index for the links in that page
![image](https://github.com/platanus/banano/assets/12057523/d92107f3-93ad-4a55-b489-6ca6539b8454)