### PR TITLE
Error messages

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vitepress';
 
+const h2 = 2;
+const h3 = 3;
+
 export default defineConfig({
   title: 'Banano',
   base: '/banano/',
@@ -45,5 +48,6 @@ export default defineConfig({
         },
       ],
     },
+    outline: [h2, h3],
   },
 });

--- a/docs/components/bn-input.md
+++ b/docs/components/bn-input.md
@@ -233,6 +233,48 @@ Due to the way Tailwind compiles classes, to avoid generating CSS for every sing
   </div>
 </code-preview>
 
+### bottom
+
+Useful for hints or errors. Includes the following slot props:
+- `errorMessage`: `vee-validate` property, if the input is invalid
+- `valid`: `vee-validate` meta property
+- `touched`: `vee-validate` meta property
+
+```html
+<BnInput
+  v-model="email"
+  name="email"
+  :rules="isRequired"
+>
+  <template #bottom="{ errorMessage, valid, touched }">
+    <span
+      class="mt-1 text-sm"
+      :class="!valid && touched ? 'text-rose-700' : 'text-gray-500'"
+    >
+      {{ !valid && touched ? errorMessage : "We'll never share your email with anyone else." }}
+    </span>
+  </template>
+</BnInput>
+```
+<code-preview>
+  <div class="grid col-span-1 gap-4">
+    <BnInput
+      v-model="email"
+      name="email"
+      :rules="isRequired"
+    >
+      <template #bottom="{ errorMessage, valid, touched }">
+        <span
+          class="mt-1 text-sm"
+          :class="!valid && touched ? 'text-rose-700' : 'text-gray-500'"
+        >
+          {{ !valid && touched ? errorMessage : "We'll never share your email with anyone else." }}
+        </span>
+      </template>
+    </BnInput>
+  </div>
+</code-preview>
+
 ## Customization
 There are three ways to customize the appearance of the `BnInput` component:
 

--- a/docs/components/bn-input.md
+++ b/docs/components/bn-input.md
@@ -6,6 +6,8 @@ import { Form, ErrorMessage } from 'vee-validate';
 const input = ref('');
 const validate = ref('');
 
+const letterIcon = 'M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z';
+
 function isRequired(val: string) {
   if (!val) {
     return 'This field is required';
@@ -97,8 +99,9 @@ Due to the way Tailwind compiles classes, to avoid generating CSS for every sing
   </div>
 </code-preview>
 
+## Slots
 
-## Prefix
+### prefix
 
 ```html
 <BnInput
@@ -110,8 +113,20 @@ Due to the way Tailwind compiles classes, to avoid generating CSS for every sing
   </template>
 </BnInput>
 ```
+<code-preview>
+  <div class="grid col-span-1 gap-4">
+    <BnInput
+      v-model="phoneNumber"
+      name="phone-number"
+    >
+      <template #prefix>
+      +56 9
+      </template>
+    </BnInput>
+  </div>
+</code-preview>
 
-### Suffix
+### suffix
 
 ```html
 <BnInput
@@ -123,6 +138,100 @@ Due to the way Tailwind compiles classes, to avoid generating CSS for every sing
   </template>
 </BnInput>
 ```
+<code-preview>
+  <div class="grid col-span-1 gap-4">
+    <BnInput
+      v-model="email"
+      name="email"
+    >
+      <template #suffix>
+      @gmail
+      </template>
+    </BnInput>
+  </div>
+</code-preview>
+
+### icon-left
+
+```html
+<BnInput
+  v-model="email"
+  name="email"
+>
+  <template #icon-left>
+    <svg
+      viewBox="0 0 24 24"
+      class="h-4 w-4 text-gray-400"
+    >
+      <path
+        fill="currentColor"
+        :d="letterIcon"
+      />
+    </svg>
+  </template>
+</BnInput>
+```
+<code-preview>
+  <div class="grid col-span-1 gap-4">
+    <BnInput
+      v-model="email"
+      name="email"
+    >
+      <template #icon-left>
+        <svg
+          viewBox="0 0 24 24"
+          class="h-4 w-4 text-gray-400"
+        >
+          <path
+            fill="currentColor"
+            :d="letterIcon"
+          />
+        </svg>
+      </template>
+    </BnInput>
+  </div>
+</code-preview>
+
+### icon-right
+
+```html
+<BnInput
+  v-model="email"
+  name="email"
+>
+  <template #icon-right>
+    <svg
+      viewBox="0 0 24 24"
+      class="h-4 w-4 text-gray-400"
+    >
+      <path
+        fill="currentColor"
+        :d="letterIcon"
+      />
+    </svg>
+  </template>
+</BnInput>
+```
+<code-preview>
+  <div class="grid col-span-1 gap-4">
+    <BnInput
+      v-model="email"
+      name="email"
+    >
+      <template #icon-right>
+        <svg
+          viewBox="0 0 24 24"
+          class="h-4 w-4 text-gray-400"
+        >
+          <path
+            fill="currentColor"
+            :d="letterIcon"
+          />
+        </svg>
+      </template>
+    </BnInput>
+  </div>
+</code-preview>
 
 ## Customization
 There are three ways to customize the appearance of the `BnInput` component:

--- a/src/components/BnFileInput/BnFileInput.story.vue
+++ b/src/components/BnFileInput/BnFileInput.story.vue
@@ -26,6 +26,10 @@ function createSVGFile(name: string, fileContent: string) {
   return file;
 }
 
+/* eslint-disable max-len, vue/max-len */
+const warningIcon = 'M11.9998 9.00006V12.7501M2.69653 16.1257C1.83114 17.6257 2.91371 19.5001 4.64544 19.5001H19.3541C21.0858 19.5001 22.1684 17.6257 21.303 16.1257L13.9487 3.37819C13.0828 1.87736 10.9167 1.87736 10.0509 3.37819L2.69653 16.1257ZM11.9998 15.7501H12.0073V15.7576H11.9998V15.7501Z';
+/* eslint-enable max-len, vue/max-len */
+
 const state = reactive({
   single: undefined,
   multiple: undefined,
@@ -34,6 +38,7 @@ const state = reactive({
     createSVGFile('icon1.svg', icons[0]),
     createSVGFile('icon2.svg', icons[1]),
   ],
+  validateCustom: undefined,
 });
 
 function isRequired(val: File[]) {
@@ -170,6 +175,42 @@ function isRequired(val: File[]) {
           name="required"
           :rules="(isRequired as GenericValidateFunction)"
         />
+      </template>
+    </Variant>
+    <Variant title="Validation with custom bottom error text">
+      <template #default>
+        <BnFileInput
+          v-model="state.validateCustom"
+          name="required"
+          :rules="(isRequired as GenericValidateFunction)"
+        >
+          <template #bottom="{ errorMessage, valid, touched }">
+            <div
+              v-if="!valid && touched"
+              class="mt-1 flex items-center text-rose-700"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+              <span class="mr-1">
+                {{ errorMessage }}
+              </span>
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+            </div>
+          </template>
+        </BnFileInput>
       </template>
     </Variant>
   </Story>

--- a/src/components/BnFileInput/BnFileInput.styles.cjs
+++ b/src/components/BnFileInput/BnFileInput.styles.cjs
@@ -1,16 +1,24 @@
 module.exports = {
   '.bn-file-input': {
     '&--variants-default': {
-      '@apply form-input flex h-12 w-full items-center rounded-lg border border-gray-200 px-3 py-2 bg-banano-bg': {},
+      '.bn-file-input__wrapper': {
+        '@apply form-input flex h-12 w-full items-center rounded-lg border border-gray-200 px-3 py-2 bg-banano-bg': {},
+      },
     },
     '&--disabled': {
-      '@apply bg-gray-100 opacity-75 cursor-not-allowed': {},
+      '.bn-file-input__wrapper': {
+        '@apply bg-gray-100 opacity-75 cursor-not-allowed': {},
+      },
     },
     '&--custom': {
-      '@apply p-0 border-0 h-auto bg-banano-bg text-banano-text-foreground': {},
+      '.bn-file-input__wrapper': {
+        '@apply p-0 border-0 h-auto bg-banano-bg text-banano-text-foreground': {},
+      },
     },
     '&--error': {
-      '@apply border border-banano-error !important': {},
+      '.bn-file-input__wrapper': {
+        '@apply border border-banano-error !important': {},
+      },
     },
     '&__input': {
       '@apply hidden': {},
@@ -34,6 +42,9 @@ module.exports = {
         '@apply rounded-full overflow-hidden': {},
       },
       '@apply disabled:bg-gray-100 disabled:opacity-75 disabled:cursor-not-allowed': {},
+    },
+    '&__error-message': {
+      '@apply text-banano-error text-sm px-4': {},
     },
   },
 };

--- a/src/components/BnFileInput/BnFileInput.vue
+++ b/src/components/BnFileInput/BnFileInput.vue
@@ -40,8 +40,10 @@ const {
   handleChange,
   setTouched,
   meta,
+  errorMessage,
 } = useField<File[]>(props.name, props.rules, {
   initialValue: props.modelValue,
+  validateOnMount: true,
 });
 
 function updateInputFiles() {
@@ -117,8 +119,7 @@ function removeFile(file: File) {
 </script>
 
 <template>
-  <component
-    :is="$slots['default'] ? 'div' : 'label'"
+  <div
     class="bn-file-input"
     :class="[
       `bn-file-input--${props.color}`,
@@ -130,85 +131,104 @@ function removeFile(file: File) {
       }
     ]"
   >
-    <input
-      ref="fileInputRef"
-      type="file"
-      :name="name"
-      class="bn-file-input__input"
-      :multiple="props.multiple"
-      :disabled="props.disabled"
-      @change="setFile"
-      @blur="handleBlur"
+    <component
+      :is="$slots['default'] ? 'div' : 'label'"
+      class="bn-file-input__wrapper"
     >
-    <slot
-      :open-file-dialog="openFileDialog"
-      :disabled="disabled"
-      :image-preview-path="imagePreviewPath"
-      :remove-file="removeFile"
-      :add-file="addFile"
-      :files="inputValue"
-    >
-      <template v-if="variant === 'default'">
-        <BnBtn
-          size="xs"
-          class="bn-file-input__button"
-          variant="outline"
-          :disabled="props.disabled"
-          @click="openFileDialog"
-        >
-          Browse
-        </BnBtn>
-      </template>
-      <template v-if="variant === 'avatar'">
-        <button
-          class="bn-file-input__avatar"
-          :class="`bn-file-input__avatar--${props.avatarShape}`"
-          :disabled="props.disabled"
-          @click="openFileDialog"
-        >
-          <img
-            v-if="inputValue && inputValue[0] && imagePreviewPath(inputValue[0])"
-            :src="imagePreviewPath(inputValue[0])"
-            class="h-full w-full object-cover"
-          >
-          <template v-else>
-            +
-          </template>
-        </button>
-      </template>
-      <div
-        v-if="variant !== 'avatar'"
-        class="bn-file-input__label"
+      <input
+        ref="fileInputRef"
+        type="file"
+        :name="name"
+        class="bn-file-input__input"
+        :multiple="props.multiple"
+        :disabled="props.disabled"
+        @change="setFile"
+        @blur="handleBlur"
       >
-        <div
-          v-if="fileList"
-          class="flex w-full items-center"
-        >
-          <span class="truncate">
-            {{ fileList }}
-          </span>
-          <button
-            class="ml-auto shrink-0 text-gray-500"
-            @click="inputValue = []"
+      <slot
+        :open-file-dialog="openFileDialog"
+        :disabled="disabled"
+        :image-preview-path="imagePreviewPath"
+        :remove-file="removeFile"
+        :add-file="addFile"
+        :files="inputValue"
+      >
+        <template v-if="variant === 'default'">
+          <BnBtn
+            size="xs"
+            class="bn-file-input__button"
+            variant="outline"
+            :disabled="props.disabled"
+            @click="openFileDialog"
           >
-            <svg
-              class="h-5 w-5"
-              viewBox="0 0 24 24"
+            Browse
+          </BnBtn>
+        </template>
+        <template v-if="variant === 'avatar'">
+          <button
+            class="bn-file-input__avatar"
+            :class="`bn-file-input__avatar--${props.avatarShape}`"
+            :disabled="props.disabled"
+            @click="openFileDialog"
+          >
+            <img
+              v-if="inputValue && inputValue[0] && imagePreviewPath(inputValue[0])"
+              :src="imagePreviewPath(inputValue[0])"
+              class="h-full w-full object-cover"
             >
-              <path
-                fill="currentColor"
-                d="M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19M8.46,11.88L9.87,10.47L12,12.59L14.12,10.47L15.53,11.88L13.41,14L15.53,16.12L14.12,17.53L12,15.41L9.88,17.53L8.47,16.12L10.59,14L8.46,11.88M15.5,4L14.5,3H9.5L8.5,4H5V6H19V4H15.5Z"
-              />
-            </svg>
+            <template v-else>
+              +
+            </template>
           </button>
-        </div>
-        <span
-          v-else
-          class="bn-file-input__placeholder"
+        </template>
+        <div
+          v-if="variant !== 'avatar'"
+          class="bn-file-input__label"
         >
-          {{ props.placeholder }}
-        </span>
-      </div>
+          <div
+            v-if="fileList"
+            class="flex w-full items-center"
+          >
+            <span class="truncate">
+              {{ fileList }}
+            </span>
+            <button
+              class="ml-auto shrink-0 text-gray-500"
+              @click="inputValue = []"
+            >
+              <svg
+                class="h-5 w-5"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  fill="currentColor"
+                  d="M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19M8.46,11.88L9.87,10.47L12,12.59L14.12,10.47L15.53,11.88L13.41,14L15.53,16.12L14.12,17.53L12,15.41L9.88,17.53L8.47,16.12L10.59,14L8.46,11.88M15.5,4L14.5,3H9.5L8.5,4H5V6H19V4H15.5Z"
+                />
+              </svg>
+            </button>
+          </div>
+          <span
+            v-else
+            class="bn-file-input__placeholder"
+          >
+            {{ props.placeholder }}
+          </span>
+        </div>
+      </slot>
+    </component>
+    <slot
+      name="bottom"
+      :error-message="errorMessage"
+      :valid="meta.valid"
+      :touched="meta.touched"
+    >
+      <p
+        v-if="!meta.valid && meta.touched"
+        :name="name"
+        class="bn-file-input__error-message"
+      >
+        {{ errorMessage }}
+      </p>
     </slot>
-  </component>
+  </div>
 </template>

--- a/src/components/BnInput/BnInput.story.vue
+++ b/src/components/BnInput/BnInput.story.vue
@@ -7,10 +7,13 @@ const state = reactive({
   value: 'Hello world!',
   emptyValue: undefined,
   validate: undefined,
+  validateCustom: undefined,
 });
 
-// eslint-disable-next-line max-len, vue/max-len
+/* eslint-disable max-len, vue/max-len */
 const letterIcon = 'M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z';
+const warningIcon = 'M11.9998 9.00006V12.7501M2.69653 16.1257C1.83114 17.6257 2.91371 19.5001 4.64544 19.5001H19.3541C21.0858 19.5001 22.1684 17.6257 21.303 16.1257L13.9487 3.37819C13.0828 1.87736 10.9167 1.87736 10.0509 3.37819L2.69653 16.1257ZM11.9998 15.7501H12.0073V15.7576H11.9998V15.7501Z';
+/* eslint-enable max-len, vue/max-len */
 
 function isRequired(val: string) {
   if (!val) {
@@ -61,7 +64,7 @@ function isRequired(val: string) {
           <template #icon-left>
             <svg
               viewBox="0 0 24 24"
-              class="w-4 h-4 text-gray-400"
+              class="h-4 w-4 text-gray-400"
             >
               <path
                 fill="currentColor"
@@ -72,7 +75,7 @@ function isRequired(val: string) {
           <template #icon-right>
             <svg
               viewBox="0 0 24 24"
-              class="w-4 h-4 text-gray-400"
+              class="h-4 w-4 text-gray-400"
             >
               <path
                 fill="currentColor"
@@ -119,7 +122,7 @@ function isRequired(val: string) {
           <template #icon-left>
             <svg
               viewBox="0 0 24 24"
-              class="w-4 h-4 text-gray-400"
+              class="h-4 w-4 text-gray-400"
             >
               <path
                 fill="currentColor"
@@ -140,6 +143,42 @@ function isRequired(val: string) {
           name="validation"
           :rules="(isRequired as GenericValidateFunction)"
         />
+      </template>
+    </Variant>
+    <Variant title="Validation with custom bottom error text">
+      <template #default>
+        <BnInput
+          v-model="state.validateCustom"
+          name="validation"
+          :rules="(isRequired as GenericValidateFunction)"
+        >
+          <template #bottom="{ errorMessage, valid, touched }">
+            <div
+              v-if="!valid && touched"
+              class="mt-1 flex items-center text-rose-700"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+              <span class="mr-1">
+                {{ errorMessage }}
+              </span>
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+            </div>
+          </template>
+        </BnInput>
       </template>
     </Variant>
   </Story>

--- a/src/components/BnInput/BnInput.styles.cjs
+++ b/src/components/BnInput/BnInput.styles.cjs
@@ -1,6 +1,8 @@
 module.exports = {
   '.bn-input': {
-    '@apply w-full flex': {},
+    '&__wrapper': {
+      '@apply w-full flex': {},
+    },
     '&__input': {
       '@apply py-3 px-3 w-full rounded-lg border border-gray-200 h-12 text-banano-text-foreground bg-banano-bg': {},
       '@apply placeholder:text-banano-text-muted': {},
@@ -37,6 +39,9 @@ module.exports = {
     '&__suffix': {
       '@apply px-3 py-2 flex items-center justify-center flex-shrink-0  rounded-r-lg': {},
       '@apply bg-gray-50 border-gray-200 border border-l-0 text-gray-500': {},
+    },
+    '&__error-message': {
+      '@apply text-banano-error text-sm px-4': {},
     },
   },
 };

--- a/src/components/BnInput/BnInput.vue
+++ b/src/components/BnInput/BnInput.vue
@@ -24,9 +24,11 @@ const {
   handleBlur,
   handleChange,
   meta,
+  errorMessage,
 } = useField(name, props.rules, {
   initialValue: props.modelValue,
   valueProp: props.modelValue,
+  validateOnMount: true,
 });
 
 function onInput(event: Event) {
@@ -50,48 +52,64 @@ export default {
     class="bn-input"
     :class="`bn-input--${props.color} ${attrs.class ? attrs.class : ''}`"
   >
-    <div
-      v-if="$slots['prefix']"
-      class="bn-input__prefix"
-    >
-      <slot name="prefix" />
-    </div>
-    <div class="relative w-full">
+    <div class="bn-input__wrapper">
       <div
-        v-if="$slots['icon-left']"
-        class="bn-input__icon-left"
+        v-if="$slots['prefix']"
+        class="bn-input__prefix"
       >
-        <slot name="icon-left" />
+        <slot name="prefix" />
       </div>
-      <input
-        v-bind="attrsWithoutClass"
-        :id="name"
-        :value="inputValue"
+      <div class="relative w-full">
+        <div
+          v-if="$slots['icon-left']"
+          class="bn-input__icon-left"
+        >
+          <slot name="icon-left" />
+        </div>
+        <input
+          v-bind="attrsWithoutClass"
+          :id="name"
+          :value="inputValue"
+          :name="name"
+          class="bn-input__input"
+          :class="{
+            'bn-input__input--icon-left': $slots['icon-left'],
+            'bn-input__input--icon-right': $slots['icon-right'],
+            'bn-input__input--prefix': $slots['prefix'],
+            'bn-input__input--suffix': $slots['suffix'],
+            'bn-input__input--error': !meta.valid && meta.touched,
+          }"
+          @input="onInput"
+          @blur="handleBlur"
+        >
+        <div
+          v-if="$slots['icon-right']"
+          class="bn-input__icon-right"
+        >
+          <slot name="icon-right" />
+        </div>
+      </div>
+      <div
+        v-if="$slots['suffix']"
+        class="bn-input__suffix"
+      >
+        <slot name="suffix" />
+      </div>
+    </div>
+    <slot
+      name="bottom"
+      :error-message="errorMessage"
+      :valid="meta.valid"
+      :touched="meta.touched"
+    >
+      <p
+        v-if="!meta.valid && meta.touched"
         :name="name"
-        class="bn-input__input"
-        :class="{
-          'bn-input__input--icon-left': $slots['icon-left'],
-          'bn-input__input--icon-right': $slots['icon-right'],
-          'bn-input__input--prefix': $slots['prefix'],
-          'bn-input__input--suffix': $slots['suffix'],
-          'bn-input__input--error': !meta.valid && meta.touched,
-        }"
-        @input="onInput"
-        @blur="handleBlur"
+        class="bn-input__error-message"
       >
-      <div
-        v-if="$slots['icon-right']"
-        class="bn-input__icon-right"
-      >
-        <slot name="icon-right" />
-      </div>
-    </div>
-    <div
-      v-if="$slots['suffix']"
-      class="bn-input__suffix"
-    >
-      <slot name="suffix" />
-    </div>
+        {{ errorMessage }}
+      </p>
+    </slot>
   </div>
 </template>
 

--- a/src/components/BnListbox/BnListbox.story.vue
+++ b/src/components/BnListbox/BnListbox.story.vue
@@ -10,6 +10,7 @@ const state = reactive({
   objectMultiple: [{ name: 'Label 1', id: 1 }, { name: 'Label 2', id: 2 }],
   empty: undefined,
   validate: undefined,
+  validateCustom: undefined,
 });
 
 const selectOptions = [
@@ -32,6 +33,10 @@ const selectOptionsWithEmpty = [
   '',
   ...selectOptions,
 ];
+
+/* eslint-disable max-len, vue/max-len */
+const warningIcon = 'M11.9998 9.00006V12.7501M2.69653 16.1257C1.83114 17.6257 2.91371 19.5001 4.64544 19.5001H19.3541C21.0858 19.5001 22.1684 17.6257 21.303 16.1257L13.9487 3.37819C13.0828 1.87736 10.9167 1.87736 10.0509 3.37819L2.69653 16.1257ZM11.9998 15.7501H12.0073V15.7576H11.9998V15.7501Z';
+/* eslint-enable max-len, vue/max-len */
 
 function isRequired(val: string) {
   if (!val) {
@@ -189,6 +194,44 @@ function isRequired(val: string) {
           placeholder="Please select an option"
           :rules="(isRequired as GenericValidateFunction)"
         />
+      </template>
+    </Variant>
+    <Variant title="Validation with custom bottom error text">
+      <template #default>
+        <BnListbox
+          v-model="state.validateCustom"
+          :options="selectOptionsWithEmpty"
+          name="validation"
+          placeholder="Please select an option"
+          :rules="(isRequired as GenericValidateFunction)"
+        >
+          <template #bottom="{ errorMessage, valid, touched }">
+            <div
+              v-if="!valid && touched"
+              class="mt-1 flex items-center text-rose-700"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+              <span class="mr-1">
+                {{ errorMessage }}
+              </span>
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+            </div>
+          </template>
+        </BnListbox>
       </template>
     </Variant>
   </Story>

--- a/src/components/BnListbox/BnListbox.styles.cjs
+++ b/src/components/BnListbox/BnListbox.styles.cjs
@@ -1,7 +1,9 @@
 module.exports = {
   '.bn-listbox': {
     '&--disabled': {
-      '@apply cursor-not-allowed bg-gray-100 opacity-75': {},
+      '.bn-listbox__listbox': {
+        '@apply cursor-not-allowed bg-gray-100 opacity-75': {},
+      },
     },
     '&__button': {
       '@apply flex h-12 w-full items-center truncate rounded-lg border border-gray-200 p-3 bg-banano-bg': {},
@@ -22,7 +24,7 @@ module.exports = {
       },
     },
     '&__error-message': {
-      '@apply text-sm text-red-600': {},
+      '@apply text-banano-error text-sm px-4': {},
     },
     '&__placeholder': {
       '@apply text-banano-text-muted': {},

--- a/src/components/BnTextarea/BnTextarea.story.vue
+++ b/src/components/BnTextarea/BnTextarea.story.vue
@@ -6,7 +6,12 @@ import BnTextarea from './BnTextarea.vue';
 const state = reactive({
   value: 'Hello world!',
   validate: undefined,
+  validateCustom: undefined,
 });
+
+/* eslint-disable max-len, vue/max-len */
+const warningIcon = 'M11.9998 9.00006V12.7501M2.69653 16.1257C1.83114 17.6257 2.91371 19.5001 4.64544 19.5001H19.3541C21.0858 19.5001 22.1684 17.6257 21.303 16.1257L13.9487 3.37819C13.0828 1.87736 10.9167 1.87736 10.0509 3.37819L2.69653 16.1257ZM11.9998 15.7501H12.0073V15.7576H11.9998V15.7501Z';
+/* eslint-enable max-len, vue/max-len */
 
 function isRequired(val: string) {
   if (!val) {
@@ -56,6 +61,43 @@ function isRequired(val: string) {
           :rules="(isRequired as GenericValidateFunction)"
           placeholder="Once upon a time..."
         />
+      </template>
+    </Variant>
+    <Variant title="Validation with custom bottom error text">
+      <template #default>
+        <BnTextarea
+          v-model="state.validateCustom"
+          name="validation"
+          :rules="(isRequired as GenericValidateFunction)"
+          placeholder="Once upon a time..."
+        >
+          <template #bottom="{ errorMessage, valid, touched }">
+            <div
+              v-if="!valid && touched"
+              class="mt-1 flex items-center text-rose-700"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+              <span class="mr-1">
+                {{ errorMessage }}
+              </span>
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+            </div>
+          </template>
+        </BnTextarea>
       </template>
     </Variant>
   </Story>

--- a/src/components/BnTextarea/BnTextarea.styles.cjs
+++ b/src/components/BnTextarea/BnTextarea.styles.cjs
@@ -1,14 +1,21 @@
 module.exports = {
   '.bn-textarea': {
-    '@apply w-full': {},
-    '@apply py-3 px-3 rounded-lg border border-gray-200 text-banano-text-foreground bg-banano-bg': {},
-    '@apply placeholder:text-banano-text-muted focus:outline-none focus:ring': {},
-    '@apply disabled:bg-gray-100 disabled:opacity-75 disabled:cursor-not-allowed': {},
-    colors: {
-      '@apply focus:border-varColor-600 focus:ring-varColor-600/25': {},
+    '&__textarea': {
+      '@apply w-full': {},
+      '@apply py-3 px-3 rounded-lg border border-gray-200 text-banano-text-foreground bg-banano-bg': {},
+      '@apply placeholder:text-banano-text-muted focus:outline-none focus:ring': {},
+      '@apply disabled:bg-gray-100 disabled:opacity-75 disabled:cursor-not-allowed': {},
+      colors: {
+        '@apply focus:border-varColor-600 focus:ring-varColor-600/25': {},
+      },
     },
     '&--error': {
-      '@apply border border-banano-error focus:ring-banano-error/25 !important': {},
+      '.bn-textarea__textarea': {
+        '@apply border-banano-error focus:ring-banano-error/25 !important': {},
+      },
+    },
+    '&__error-message': {
+      '@apply text-banano-error text-sm px-4': {},
     },
   },
 };

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -25,9 +25,11 @@ const {
   handleBlur,
   handleChange,
   meta,
+  errorMessage,
 } = useField(name, props.rules, {
   initialValue: props.modelValue,
   valueProp: props.modelValue,
+  validateOnMount: true,
 });
 
 function onInput(event: Event) {
@@ -40,15 +42,33 @@ const attrs = useAttrs();
 </script>
 
 <template>
-  <textarea
+  <div
     class="bn-textarea"
     :class="[
       `bn-textarea--${props.color} ${attrs.class ? attrs.class : ''}`,
       {'bn-textarea--error': !meta.valid && meta.touched},
     ]"
-    :value="(inputValue as string)"
-    :name="name"
-    @input="onInput"
-    @blur="handleBlur"
-  />
+  >
+    <textarea
+      class="bn-textarea__textarea"
+      :value="(inputValue as string)"
+      :name="name"
+      @input="onInput"
+      @blur="handleBlur"
+    />
+    <slot
+      name="bottom"
+      :error-message="errorMessage"
+      :valid="meta.valid"
+      :touched="meta.touched"
+    >
+      <p
+        v-if="!meta.valid && meta.touched"
+        :name="name"
+        class="bn-textarea__error-message"
+      >
+        {{ errorMessage }}
+      </p>
+    </slot>
+  </div>
 </template>

--- a/src/components/BnToggle/BnToggle.story.vue
+++ b/src/components/BnToggle/BnToggle.story.vue
@@ -25,7 +25,12 @@ const state = reactive({
   array: ['Item 1', 'Item 2'],
   object: [],
   disabled: undefined,
+  validateCustom: undefined,
 });
+
+/* eslint-disable max-len, vue/max-len */
+const warningIcon = 'M11.9998 9.00006V12.7501M2.69653 16.1257C1.83114 17.6257 2.91371 19.5001 4.64544 19.5001H19.3541C21.0858 19.5001 22.1684 17.6257 21.303 16.1257L13.9487 3.37819C13.0828 1.87736 10.9167 1.87736 10.0509 3.37819L2.69653 16.1257ZM11.9998 15.7501H12.0073V15.7576H11.9998V15.7501Z';
+/* eslint-enable max-len, vue/max-len */
 
 function isRequired(val: string) {
   if (!val) {
@@ -118,6 +123,45 @@ function isRequired(val: string) {
           color="lime"
         >
           This is a toggle
+        </BnToggle>
+      </template>
+    </Variant>
+    <Variant title="Validation with custom bottom error text">
+      <template #default>
+        <BnToggle
+          v-model="state.validateCustom"
+          :rules="(isRequired as GenericValidateFunction)"
+          name="color"
+          value="Checked"
+          color="lime"
+        >
+          This is a toggle
+          <template #bottom="{ errorMessage, valid, touched }">
+            <div
+              v-if="!valid && touched"
+              class="mt-1 flex items-center text-rose-700"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+              <span class="mr-1">
+                {{ errorMessage }}
+              </span>
+              <svg
+                viewBox="0 0 24 24"
+                class="fill-none mr-1 h-4 w-4 stroke-current stroke-2"
+              >
+                <path
+                  :d="warningIcon"
+                />
+              </svg>
+            </div>
+          </template>
         </BnToggle>
       </template>
     </Variant>

--- a/src/components/BnToggle/BnToggle.styles.cjs
+++ b/src/components/BnToggle/BnToggle.styles.cjs
@@ -1,16 +1,19 @@
 module.exports = {
   '.bn-toggle': {
-    '@apply flex items-center': {},
+    '&__wrapper': {
+      '@apply flex items-center': {},
+    },
     '&--disabled': {
-      '@apply cursor-not-allowed opacity-75': {},
+      '.bn-toggle__wrapper': {
+        '@apply cursor-not-allowed opacity-75': {},
+      },
     },
     '&--error': {
-      '@apply text-banano-error': {},
       '.bn-toggle__input': {
         '@apply border-banano-error': {},
       },
     },
-    '&__wrapper': {
+    '&__toggle': {
       '@apply relative mr-2 h-6 w-12 cursor-pointer items-center justify-center': {},
     },
     '&__track': {
@@ -35,6 +38,9 @@ module.exports = {
           '@apply ring-2 ring-offset-4 ring-varColor-500': {},
         },
       },
+    },
+    '&__error-message': {
+      '@apply text-banano-error text-sm px-4': {},
     },
   },
 };

--- a/src/components/BnToggle/BnToggle.vue
+++ b/src/components/BnToggle/BnToggle.vue
@@ -25,10 +25,11 @@ const emit = defineEmits<{(e: 'update:modelValue', value: valueTypes | valueType
 
 const name = toRef(props, 'name');
 
-const { handleChange, checked, meta, setTouched } = useField(props.name, props.rules, {
+const { handleChange, checked, meta, setTouched, errorMessage } = useField(props.name, props.rules, {
   type: 'checkbox',
   checkedValue: props.value,
   initialValue: props.modelValue,
+  validateOnMount: true,
 });
 
 function onChange(e: Event) {
@@ -54,7 +55,7 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
 </script>
 
 <template>
-  <label
+  <div
     class="bn-toggle"
     :class="[
       `bn-toggle--${props.color}`,
@@ -62,20 +63,36 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
       {'bn-toggle--disabled': props.disabled},
     ]"
   >
-    <div class="bn-toggle__wrapper">
-      <input
-        :checked="checked"
-        :value="value"
-        type="checkbox"
+    <label class="bn-toggle__wrapper">
+      <div class="bn-toggle__toggle">
+        <input
+          :checked="checked"
+          :value="value"
+          type="checkbox"
+          :name="name"
+          class="bn-toggle__input"
+          v-bind="attrsWithoutClass"
+          :disabled="props.disabled"
+          @change="onChange"
+        >
+        <div class="bn-toggle__track" />
+        <div class="bn-toggle__ball" />
+      </div>
+      <slot />
+    </label>
+    <slot
+      name="bottom"
+      :error-message="errorMessage"
+      :valid="meta.valid"
+      :touched="meta.touched"
+    >
+      <p
+        v-if="!meta.valid && meta.touched"
         :name="name"
-        class="bn-toggle__input "
-        v-bind="attrsWithoutClass"
-        :disabled="props.disabled"
-        @change="onChange"
+        class="bn-toggle__error-message"
       >
-      <div class="bn-toggle__track" />
-      <div class="bn-toggle__ball" />
-    </div>
-    <slot />
-  </label>
+        {{ errorMessage }}
+      </p>
+    </slot>
+  </div>
 </template>


### PR DESCRIPTION
### Context

- Currently, banano has a bunch of components with some customization options. Most of this components have some error state that comes with a few style changes. In #3, we added a theme-customizable color for error related styling.
- Previously, there was an error message for inputs but it was removed in https://github.com/platanus/banano/commit/905f384468023c86f6bb92bdfcaf6677a6bf2fc9

### Changes

This PR restores the error messages:
 - Documents slots in the only documented component, `bn-input`
 - Configure vitepress to show `h3`s
 - Added `bottom` slot for input components (except checkbox, which will be covered in the future). This slot has a default value that that shows an error message, and it provides slot props to customize it. Some details:
   -  `bn-input` include documentation of new slot
   - A story with a custom bottom text was added for all inputs
   - In general, my approach was to wrap all the template of each input in a div. This new div would have the root css name, and the previous one would now have the suffix `__wrapper`, then the slot would be inserted as the las child of the root, and changes to the css were made accordingly. Not sure this approach or naming were the best, open to suggestions
   - I added `validateOnMount` to all inputs. This because it controls wether the `errorMessage` is populated on mount or not, but the `meta.valid` value would be false either way (because of required validation), so it would happen that if you focused on the element and then blurred without changing the value, the `met.touched` would change to true and the border would be red, but the `errorMessage` didn't show as it didn't exist yet without the `validateOnMount` 
   - To the `bn-toggle`, I removed the red color from the default slot text, as it was too much when including the error message in red also

### Images of default error inputs:

**BnFileInput**
![image](https://github.com/platanus/banano/assets/12057523/2be01c07-ebc1-462c-b0dd-71981b50fe7c)

**BnInput**
![image](https://github.com/platanus/banano/assets/12057523/0983932a-1b74-4df4-83ce-3f44410927f1)

**BnListbox**
![image](https://github.com/platanus/banano/assets/12057523/f1004af7-2914-4f1d-a29b-3c50af5c5a64)

**BnTextarea**
![image](https://github.com/platanus/banano/assets/12057523/77d037e5-4341-4c47-b1fc-430148ff1abb)

**BnToggle**
![image](https://github.com/platanus/banano/assets/12057523/25380fda-e4b8-4187-8b0e-2cb691d16ace)
