### PR TITLE
Document localization

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -32,6 +32,10 @@ export default defineConfig({
               ],
             },
             {
+              text: 'Localization',
+              link: '/localization',
+            },
+            {
               text: 'Histoire (Component Library)',
               link: 'https://platanus.github.io/banano/histoire/',
             },

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,5 @@
+# Localization
+
+You can customize any text in banano's components:
+- For validation we use [vee-validate](https://vee-validate.logaretm.com/v4/guide/overview/), with it you can customize any validation message. We mostly use `yup` for validation rules, so you can use `useLocale` with something like [yup-locales](https://github.com/loicmahieu/yup-locales) or your custom translations object. Check out [yup's documentation on localization](https://github.com/jquense/yup#localization-and-i18n) for more information.
+- You can modify other text elements, such as `BnFileInput`'s `placeholder` and `buttonText`, by using their respective props. Currently, there is no way to change these props' default values globally, so you would have to change them in a per-instance basis.

--- a/src/components/BnFileInput/BnFileInput.vue
+++ b/src/components/BnFileInput/BnFileInput.vue
@@ -10,6 +10,7 @@ interface Props {
   rules?: RuleExpression<unknown>
   multiple?: boolean
   disabled?: boolean
+  buttonText?: string
   placeholder?: string
   variant?: string
   avatarShape?: string
@@ -22,6 +23,7 @@ const props = withDefaults(defineProps<Props>(), {
   multiple: false,
   disabled: false,
   placeholder: 'No file selected',
+  buttonText: 'Browse',
   variant: 'default',
   avatarShape: 'default',
 });
@@ -161,7 +163,7 @@ function removeFile(file: File) {
             :disabled="props.disabled"
             @click="openFileDialog"
           >
-            Browse
+            {{ props.buttonText }}
           </BnBtn>
         </template>
         <template v-if="variant === 'avatar'">


### PR DESCRIPTION
## Context

- Banano is a component library meant for use in Platanus projects. It has a bunch of components with configuration options to provide a base to begin building fast.
- Banano uses `vee-validate` to provide support input validation. Components show the `errorMessage` as default value in a slot in input components

## Changes

This PR documents localization:
- Adds `buttonText` prop to `BnFileInput`, which was the only non-validation text that wasn't available as a prop
- Adds docs page explaining how to localize error messages texts using yup, and other texts using props