### PR TITLE
Replace tailwind classes with customizable bem classes

### DIFF
--- a/src/components/BnFileInput/BnFileInput.styles.cjs
+++ b/src/components/BnFileInput/BnFileInput.styles.cjs
@@ -29,6 +29,18 @@ module.exports = {
     '&__label': {
       '@apply w-full overflow-hidden text-sm text-banano-text-foreground': {},
     },
+    '&__file-list': {
+      '@apply flex w-full items-center': {},
+    },
+    '&__file-names': {
+      '@apply truncate': {},
+    },
+    '&__clear-button': {
+      '@apply ml-auto shrink-0 text-gray-500': {},
+    },
+    '&__clear-button-icon': {
+      '@apply h-5 w-5': {},
+    },
     '&__placeholder': {
       '@apply text-banano-text-muted': {},
     },
@@ -42,6 +54,9 @@ module.exports = {
         '@apply rounded-full overflow-hidden': {},
       },
       '@apply disabled:bg-gray-100 disabled:opacity-75 disabled:cursor-not-allowed': {},
+    },
+    '&__avatar-preview': {
+      '@apply w-full h-full object-cover': {},
     },
     '&__error-message': {
       '@apply text-banano-error text-sm px-4': {},

--- a/src/components/BnFileInput/BnFileInput.vue
+++ b/src/components/BnFileInput/BnFileInput.vue
@@ -84,7 +84,7 @@ watch(
   },
 );
 
-const fileList = computed(() => {
+const fileNames = computed(() => {
   if (inputValue.value) {
     return inputValue.value.map((file) => file.name).join(', ');
   }
@@ -176,7 +176,7 @@ function removeFile(file: File) {
             <img
               v-if="inputValue && inputValue[0] && imagePreviewPath(inputValue[0])"
               :src="imagePreviewPath(inputValue[0])"
-              class="h-full w-full object-cover"
+              class="bn-file-input__avatar-preview"
             >
             <template v-else>
               +
@@ -188,18 +188,18 @@ function removeFile(file: File) {
           class="bn-file-input__label"
         >
           <div
-            v-if="fileList"
-            class="flex w-full items-center"
+            v-if="fileNames"
+            class="bn-file-input__file-list"
           >
-            <span class="truncate">
-              {{ fileList }}
+            <span class="bn-file-input__file-names">
+              {{ fileNames }}
             </span>
             <button
-              class="ml-auto shrink-0 text-gray-500"
+              class="bn-file-input__clear-button"
               @click="inputValue = []"
             >
               <svg
-                class="h-5 w-5"
+                class="bn-file-input__clear-button-icon"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/components/BnInput/BnInput.styles.cjs
+++ b/src/components/BnInput/BnInput.styles.cjs
@@ -26,6 +26,9 @@ module.exports = {
         '@apply border-banano-error focus:ring-banano-error/25 !important': {},
       },
     },
+    '&__input-and-icons-wrapper': {
+      '@apply relative w-full': {},
+    },
     '&__icon-left': {
       '@apply absolute top-0 left-0 bottom-0 flex items-center justify-center w-10': {},
     },

--- a/src/components/BnInput/BnInput.vue
+++ b/src/components/BnInput/BnInput.vue
@@ -59,7 +59,7 @@ export default {
       >
         <slot name="prefix" />
       </div>
-      <div class="relative w-full">
+      <div class="bn-input__input-and-icons-wrapper">
         <div
           v-if="$slots['icon-left']"
           class="bn-input__icon-left"

--- a/src/components/BnListbox/BnListbox.styles.cjs
+++ b/src/components/BnListbox/BnListbox.styles.cjs
@@ -17,11 +17,20 @@ module.exports = {
         '@apply ui-open:ring-varColor-600/25 focus:ring-varColor-600/25': {},
       },
     },
+    '&__tags': {
+      '@apply overflow-hidden': {},
+    },
     '&__tag': {
       '@apply ml-1 inline-flex rounded py-1 px-2': {},
       colors: {
         '@apply bg-varColor-100': {},
       },
+    },
+    '&__selected-value': {
+      '@apply truncate': {},
+    },
+    '&__icon': {
+      '@apply ml-auto h-6 w-6 shrink-0 text-gray-500': {},
     },
     '&__error-message': {
       '@apply text-banano-error text-sm px-4': {},
@@ -38,6 +47,12 @@ module.exports = {
       colors: {
         '@apply hover:bg-varColor-600 ui-selected:bg-varColor-600': {},
       },
+    },
+    '&__option-text': {
+      '@apply truncate': {},
+    },
+    '&__selected-option-icon': {
+      '@apply ml-auto h-3.5 w-4 shrink-0': {},
     },
   },
 };

--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -119,37 +119,37 @@ watch(
         >
           {{ placeholder }}
         </span>
-        <template v-else-if="multiple && !isEmpty(value)">
-          <div class="overflow-hidden">
-            <template
-              v-for="option in (value as string[] | Record<string, unknown>[])"
-              :key="isObjectValue(option) ?
-                option[props.trackBy] as string : option as string"
+        <div
+          v-else-if="multiple && !isEmpty(value)"
+          class="bn-listbox__tags"
+        >
+          <template
+            v-for="option in (value as string[] | Record<string, unknown>[])"
+            :key="isObjectValue(option) ? (option[props.trackBy] as string) : (option as string)"
+          >
+            <slot
+              name="selected-multiple-template"
+              :value="option"
             >
-              <slot
-                name="selected-multiple-template"
-                :value="option"
-              >
-                <span class="bn-listbox__tag">
-                  {{ isObjectValue(option) ? option[props.optionLabel] : option }}
-                </span>
-              </slot>
-            </template>
-          </div>
-        </template>
+              <span class="bn-listbox__tag">
+                {{ isObjectValue(option) ? option[props.optionLabel] : option }}
+              </span>
+            </slot>
+          </template>
+        </div>
         <slot
           v-else-if="!isEmpty(value)"
           name="selected-template"
           :value="value"
         >
-          <span class="truncate">
+          <span class="bn-listbox__selected-value">
             {{ isObjectValue(value as string | Record<string, unknown>) ?
               (value as Record<string, unknown>)[props.optionLabel] : value
             }}
           </span>
         </slot>
         <svg
-          class="ml-auto h-6 w-6 shrink-0 text-gray-500"
+          class="bn-listbox__icon"
           viewBox="0 0 24 24"
         >
           <path
@@ -168,7 +168,7 @@ watch(
           <ListboxOption
             v-for="option in options"
             v-slot="{ selected }"
-            :key="isObjectValue(option) ? option[props.trackBy] as string : option as string"
+            :key="isObjectValue(option) ? (option[props.trackBy] as string) : (option as string)"
             :value="option"
             class="bn-listbox-options__option"
           >
@@ -177,7 +177,7 @@ watch(
               :option="option"
               :selected="selected"
             >
-              <span class="truncate">
+              <span class="bn-listbox-options__option-text">
                 <template v-if="isObjectValue(option)">
                   {{ option[props.trackBy] ? option[props.optionLabel] : placeholder }}
                 </template>
@@ -187,7 +187,7 @@ watch(
               </span>
               <svg
                 v-if="selected"
-                class="ml-auto h-[14px] w-[18px] shrink-0"
+                class="bn-listbox-options__selected-option-icon"
                 viewBox="0 0 18 14"
                 fill="none"
               >

--- a/src/components/BnModal/BnModal.styles.cjs
+++ b/src/components/BnModal/BnModal.styles.cjs
@@ -16,6 +16,9 @@ module.exports = {
       '@apply absolute top-0 right-0 ml-auto flex h-12 w-12': {},
       '@apply items-center justify-center text-gray-500 focus:outline-none': {},
     },
+    '&__close-button-icon': {
+      '@apply h-6 w-6': {},
+    },
     '&__header': {
       '@apply flex flex-row border-b px-6 py-2 text-lg text-gray-800 font-semibold': {},
     },

--- a/src/components/BnModal/BnModal.vue
+++ b/src/components/BnModal/BnModal.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
           @click="emit('close', false)"
         >
           <svg
-            class="h-6 w-6"
+            class="bn-modal__close-button-icon"
             viewBox="0 0 24 24"
           >
             <path

--- a/src/components/Btn/Btn.styles.cjs
+++ b/src/components/Btn/Btn.styles.cjs
@@ -82,11 +82,26 @@ module.exports = {
         '@apply focus:text-varColor-400': {},
       },
     },
+    '&__icon-left': {
+      '@apply mr-2': {},
+    },
+    '&__content-and-loading-wrapper': {
+      '@apply flex shrink-0 flex-row items-center': {},
+    },
     '&__loading': {
       '@apply animate-spin mr-3': {},
       '&--no-content': {
         '@apply mr-0': {},
       },
+    },
+    '&__loading-circle': {
+      '@apply opacity-25': {},
+    },
+    '&__loading-arc': {
+      '@apply opacity-75': {},
+    },
+    '&__icon-right': {
+      '@apply ml-2': {},
     },
   },
 };

--- a/src/components/Btn/Btn.vue
+++ b/src/components/Btn/Btn.vue
@@ -46,11 +46,11 @@ const tag = computed(() => {
     <template v-if="!loading || loading && !loadingReplacesContent">
       <div
         v-if="$slots['icon-left']"
-        class="mr-2"
+        class="bn-btn__icon-left"
       >
         <slot name="icon-left" />
       </div>
-      <span class="flex-shrink-0 flex flex-row items-center">
+      <span class="bn-btn__content-and-loading-wrapper">
         <svg
           v-if="loading"
           class="bn-btn__loading"
@@ -59,7 +59,7 @@ const tag = computed(() => {
           viewBox="0 0 24 24"
         >
           <circle
-            class="opacity-25"
+            class="bn-btn__loading-circle"
             cx="12"
             cy="12"
             r="10"
@@ -67,7 +67,7 @@ const tag = computed(() => {
             stroke-width="4"
           />
           <path
-            class="opacity-75"
+            class="bn-btn__loading-arc"
             fill="currentColor"
             d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135
               5.824 3 7.938l3-2.647z"
@@ -77,7 +77,7 @@ const tag = computed(() => {
       </span>
       <div
         v-if="$slots['icon-right']"
-        class="ml-2"
+        class="bn-btn__icon-right"
       >
         <slot name="icon-right" />
       </div>
@@ -90,7 +90,7 @@ const tag = computed(() => {
         viewBox="0 0 24 24"
       >
         <circle
-          class="opacity-25"
+          class="bn-btn__loading-circle"
           cx="12"
           cy="12"
           r="10"
@@ -98,7 +98,7 @@ const tag = computed(() => {
           stroke-width="4"
         />
         <path
-          class="opacity-75"
+          class="bn-btn__loading-arc"
           fill="currentColor"
           d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135
               5.824 3 7.938l3-2.647z"


### PR DESCRIPTION
## Context
Banano is a component library meant for use in Platanus projects. It has a bunch of components with configuration options to provide a base to begin building fast

## This PR
This PR removes any tailwind class used directly in vue components, and replaces them with BEM classes, mainly to allow for customization in projects of each and every HTML element inside of the components