### PR TITLE
Feat/modify file input

### DIFF
--- a/src/components/BnFileInput/BnFIleInput.spec.ts
+++ b/src/components/BnFileInput/BnFIleInput.spec.ts
@@ -1,9 +1,0 @@
-import { mount } from '@vue/test-utils';
-import BnFileInput from './BnFileInput.vue';
-
-describe('BnFileInput', () => {
-  it('should mount', () => {
-    const wrapper = mount(BnFileInput, { props: { name: 'test' } });
-    expect(wrapper.findAll('input')).toHaveLength(1);
-  });
-});

--- a/src/components/BnFileInput/BnFileInput.spec.ts
+++ b/src/components/BnFileInput/BnFileInput.spec.ts
@@ -1,0 +1,225 @@
+import waitForExpect from 'wait-for-expect';
+import { vi } from 'vitest';
+import { mount, DOMWrapper } from '@vue/test-utils';
+import { defineComponent, type PropType } from 'vue';
+import { Form } from 'vee-validate';
+import BnFileInput, { type FileType } from './BnFileInput.vue';
+import DataTransferMock from '../../mocks/data-transfer';
+
+vi.stubGlobal('DataTransfer', DataTransferMock);
+
+function isRequired(val: FileType) {
+  if (val === undefined || val.length === 0) {
+    return 'This field is required';
+  }
+
+  return true;
+}
+
+function generateFile(name: string) {
+  return new File([name], `${name}.txt`, {
+    type: 'text/plain',
+  });
+}
+
+const baseFileInput = `<BnFileInput 
+  v-model="image"
+  name="image"
+/>`;
+
+const arrayFileInput = `<BnFileInput 
+  v-model="imagesArray"
+  name="image"
+  multiple
+/>`;
+
+const customArrayFileInput = `<BnFileInput
+v-model="imagesArray"
+name="image"
+multiple
+>
+<template #default="{ imagePreviewPath, openFileDialog, value, addFile, removeFile }">
+  <div class="w-full">
+    <button
+      id="add-file"
+      v-if="value && value.length > 0"
+      class="mb-2 rounded border border-gray-300 py-1 px-2 text-sm shadow"
+      @click="addFile()"
+    >
+      Add File
+    </button>
+    <button
+      v-else
+      class="mb-2 rounded border border-gray-300 py-1 px-2 text-sm shadow"
+      @click="openFileDialog()"
+    >
+      Browse
+    </button>
+    <ul
+      v-if="value && isFileList(value)"
+      class="w-full"
+    >
+      <li
+        v-for="file in value"
+        :key="file.name"
+        class="flex w-full items-center border border-t-0 p-1 text-sm first:border-t"
+      >
+        <img
+          :src="imagePreviewPath(file)"
+          class="mr-2 h-6 w-6 rounded-full"
+        >
+        <span class="truncate">{{ file.name }}</span> ({{ file.size / 1000 }} KB)
+        <button
+          id="remove-file"
+          class="ml-auto"
+          @click="removeFile(file)"
+        >
+          🗑
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+</BnFileInput>`;
+
+function isFileList(object: File[] | File): object is File[] {
+  return !(object instanceof File);
+}
+
+const fileInputs = {
+  single: baseFileInput,
+  multiple: arrayFileInput,
+  customMultiple: customArrayFileInput,
+};
+
+function fileInputOnChangeTrigger(fileInput: DOMWrapper<HTMLInputElement>, value: File[]) {
+  const event = document.createEvent('HTMLEvents');
+  event.initEvent('change', false, true);
+  Object.defineProperty(event, 'target', { writable: false, value: { files: value } });
+
+  fileInput.element.dispatchEvent(event);
+}
+
+function generateExampleForm(fileInputType: 'single' | 'multiple' | 'customMultiple' = 'single') {
+  return defineComponent({
+    components: {
+      Form, BnFileInput,
+    },
+    props: {
+      validationSchema: {
+        type: Object,
+        default: () => ({}),
+      },
+      initialImages: {
+        type: Array as PropType<File[]>,
+        default: () => ([]),
+      },
+    },
+    data(props): { image?: File, imagesArray: File[], submittedValues?: Record<string, unknown> } {
+      return {
+        image: undefined,
+        imagesArray: props.initialImages || [],
+        submittedValues: undefined,
+      };
+    },
+    methods: {
+      isFileList,
+      submit(values: Record<string, unknown>) {
+        this.submittedValues = values;
+      },
+    },
+    template: `
+      <Form @submit="submit" :validation-schema="validationSchema">
+        ${fileInputs[fileInputType]}
+      </Form>
+    `,
+  });
+}
+
+const file = generateFile('test');
+
+describe('BnFileInput', () => {
+  it('should mount', () => {
+    const wrapper = mount(BnFileInput, { props: { name: 'image' } });
+    expect(wrapper.findAll('input')).toHaveLength(1);
+  });
+
+  it('v-model should work', async () => {
+    const wrapper = mount(generateExampleForm());
+    const fileInput = wrapper.getComponent(BnFileInput).find('input');
+    fileInputOnChangeTrigger(fileInput, [file]);
+
+    await waitForExpect(() => {
+      expect(wrapper.vm.image).toBe(file);
+    });
+  });
+
+  it('vee-validate submit should work', async () => {
+    const wrapper = mount(generateExampleForm());
+    const fileInput = wrapper.getComponent(BnFileInput).find('input');
+    fileInputOnChangeTrigger(fileInput, [file]);
+
+    wrapper.find('form').trigger('submit');
+    await waitForExpect(() => {
+      expect(wrapper.vm.submittedValues).toStrictEqual({ image: file });
+    });
+  });
+
+  it('v-model should work with array', async () => {
+    const wrapper = mount(generateExampleForm('multiple'));
+    const fileInput = wrapper.getComponent(BnFileInput).find('input');
+    const fileList = [file, generateFile('test2')];
+    fileInputOnChangeTrigger(fileInput, fileList);
+
+    await waitForExpect(() => {
+      expect(wrapper.vm.imagesArray).toStrictEqual(fileList);
+    });
+  });
+
+  it('should validate using prop rules', async () => {
+    const wrapper = mount(BnFileInput, { props: { name: 'image', rules: isRequired } });
+    expect(wrapper.classes().includes('bn-file-input--error')).toBe(false);
+    const input = wrapper.find('button');
+    input.trigger('click');
+    await waitForExpect(() => {
+      expect(wrapper.classes().includes('bn-file-input--error')).toBe(true);
+    });
+  });
+
+  it('should validate using form rules', async () => {
+    const wrapper = mount(generateExampleForm(), { props: { validationSchema: { image: isRequired } } });
+    const input = wrapper.find('button');
+    const inputWrapper = wrapper.find('div');
+    expect(inputWrapper.classes().includes('bn-file-input--error')).toBe(false);
+    input.trigger('click');
+    await waitForExpect(() => {
+      expect(inputWrapper.classes().includes('bn-file-input--error')).toBe(true);
+    });
+  });
+
+  it('should add file', async () => {
+    const fileList = [file, generateFile('test2')];
+    const wrapper = mount(generateExampleForm('customMultiple'), { props: { initialImages: fileList } });
+    const newFile = generateFile('test3');
+
+    wrapper.find('#add-file').trigger('click');
+
+    const fileInput = wrapper.getComponent(BnFileInput).find('input');
+    fileInputOnChangeTrigger(fileInput, [newFile]);
+
+    await waitForExpect(() => {
+      expect(wrapper.vm.imagesArray).toStrictEqual([...fileList, newFile]);
+    });
+  });
+
+  it('should remove file', async () => {
+    const fileList = [generateFile('test2'), file];
+    const wrapper = mount(generateExampleForm('customMultiple'), { props: { initialImages: fileList } });
+
+    wrapper.find('#remove-file').trigger('click');
+
+    await waitForExpect(() => {
+      expect(wrapper.vm.imagesArray).toStrictEqual([file]);
+    });
+  });
+});

--- a/src/components/BnFileInput/BnFileInput.story.vue
+++ b/src/components/BnFileInput/BnFileInput.story.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { GenericValidateFunction } from 'vee-validate';
-import { reactive, Ref } from 'vue';
+import { reactive } from 'vue';
 import BnFileInput from './BnFileInput.vue';
 
 const icons = [
@@ -34,20 +34,26 @@ const state = reactive({
   single: undefined,
   multiple: undefined,
   avatar: undefined,
-  custom: [
+  customMultiple: [
     createSVGFile('icon1.svg', icons[0]),
     createSVGFile('icon2.svg', icons[1]),
   ],
   validateCustom: undefined,
+  customSingle: createSVGFile('icon1.svg', icons[0]),
 });
 
-function isRequired(val: File[]) {
-  if (val.length === 0) {
+function isFileList(object: File[] | File): object is File[] {
+  return !(object instanceof File);
+}
+
+function isRequired(val: File[] | File | undefined) {
+  if (val === undefined || val.length === 0) {
     return 'This field is required';
   }
 
   return true;
 }
+
 </script>
 
 <template>
@@ -121,17 +127,17 @@ function isRequired(val: File[]) {
         />
       </template>
     </Variant>
-    <Variant title="custom template">
+    <Variant title="custom template multiple file">
       <template #default>
         <BnFileInput
-          v-model="state.custom"
-          name="custom-template"
+          v-model="state.customMultiple"
+          name="custom-template-multiple"
           multiple
         >
-          <template #default="{ imagePreviewPath, openFileDialog, files, addFile, removeFile }">
+          <template #default="{ imagePreviewPath, openFileDialog, value, addFile, removeFile }">
             <div class="w-full">
               <button
-                v-if="files.length > 0"
+                v-if="value && value.length > 0"
                 class="mb-2 rounded border border-gray-300 py-1 px-2 text-sm shadow"
                 @click="addFile()"
               >
@@ -144,9 +150,61 @@ function isRequired(val: File[]) {
               >
                 Browse
               </button>
-              <ul class="w-full">
+              <ul
+                v-if="value && isFileList(value)"
+                class="w-full"
+              >
                 <li
-                  v-for="file in files"
+                  v-for="file in value"
+                  :key="file.name"
+                  class="flex w-full items-center border border-t-0 p-1 text-sm first:border-t"
+                >
+                  <img
+                    :src="imagePreviewPath(file)"
+                    class="mr-2 h-6 w-6 rounded-full"
+                  >
+                  <span class="truncate">{{ file.name }}</span> ({{ file.size / 1000 }} KB)
+                  <button
+                    class="ml-auto"
+                    @click="removeFile(file)"
+                  >
+                    🗑
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </template>
+        </BnFileInput>
+      </template>
+    </Variant>
+    <Variant title="custom template single file">
+      <template #default>
+        <BnFileInput
+          v-model="state.customSingle"
+          name="custom-template-single"
+        >
+          <template #default="{ imagePreviewPath, openFileDialog, value, addFile, removeFile }">
+            <div class="w-full">
+              <button
+                v-if="value"
+                class="mb-2 rounded border border-gray-300 py-1 px-2 text-sm shadow"
+                @click="addFile()"
+              >
+                Add File
+              </button>
+              <button
+                v-else
+                class="mb-2 rounded border border-gray-300 py-1 px-2 text-sm shadow"
+                @click="openFileDialog()"
+              >
+                Browse
+              </button>
+              <ul
+                v-if="value && !isFileList(value)"
+                class="w-full"
+              >
+                <li
+                  v-for="file in [value]"
                   :key="file.name"
                   class="flex w-full items-center border border-t-0 p-1 text-sm first:border-t"
                 >

--- a/src/mocks/data-transfer.ts
+++ b/src/mocks/data-transfer.ts
@@ -1,0 +1,26 @@
+
+import { vi } from 'vitest';
+
+const emptyFileList = {
+  length: 0,
+  item: () => null,
+};
+
+Object.defineProperty(HTMLInputElement.prototype, 'files', {
+  writable: true,
+  value: emptyFileList,
+});
+
+const dataTransferMock = {
+  files: emptyFileList,
+  items: {
+    add: vi.fn(),
+  },
+
+  setData: vi.fn(),
+  getData: vi.fn(),
+};
+
+export default function DataTransferMock() {
+  return dataTransferMock;
+}


### PR DESCRIPTION
## Context
Banano is a component library intended for use in Platanus projects. The BnFileInput component acts as a file input, allowing the use of v-model. In the initial implementation, this component only accepted a list of files, but did not handle single files.

## This PR

This PR enables BnFileInput to accept single files. It handles multiple scenarios, including cases where the value exists as either a File list or a single file, as well as cases where the value does not exist. Additionally, a change has been made to set the "touched" value when the dialog is open. Previously, if the dialog was open but the user didn't select any files, the validation wouldn't appear.

Furthermore, tests have been added to cover all the cases present in the component.