### PR TITLE
Unnest styles

### DIFF
--- a/src/components/BnCheckbox/BnCheckbox.styles.cjs
+++ b/src/components/BnCheckbox/BnCheckbox.styles.cjs
@@ -6,9 +6,6 @@ module.exports = {
     },
     '&--error': {
       '@apply text-banano-error !important': {},
-      '.bn-checkbox__input': {
-        '@apply border-banano-error focus:ring-banano-error !important': {},
-      },
     },
     '&__input': {
       '@apply mr-2 rounded border-gray-300 focus:outline-none focus:ring-0 focus:ring-offset-0': {},
@@ -16,6 +13,9 @@ module.exports = {
       colors: {
         '@apply text-varColor-600': {},
         '@apply focus-visible:border-varColor-600 focus-visible:ring-varColor-600': {},
+      },
+      '&--error': {
+        '@apply border-banano-error focus:ring-banano-error !important': {},
       },
     },
   },

--- a/src/components/BnCheckbox/BnCheckbox.vue
+++ b/src/components/BnCheckbox/BnCheckbox.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRef, useAttrs } from 'vue';
+import { toRef, useAttrs, computed } from 'vue';
 
 type valueTypes = undefined | boolean | string | number | Record<string, unknown>;
 
@@ -30,6 +30,7 @@ const { handleChange, checked, meta, setTouched } = useField(props.name, props.r
   checkedValue: props.value,
   initialValue: props.modelValue,
 });
+const hasError = computed(() => !meta.valid && meta.touched);
 
 function onChange(e: Event) {
   const input = e.target as HTMLInputElement;
@@ -58,7 +59,7 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
     class="bn-checkbox"
     :class="[
       `bn-checkbox--${props.color}`,
-      {'bn-checkbox--error': !meta.valid && meta.touched},
+      {'bn-checkbox--error': hasError},
       {'bn-checkbox--disabled': props.disabled},
     ]"
   >
@@ -68,6 +69,7 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
       type="checkbox"
       :name="name"
       class="bn-checkbox__input"
+      :class="{'bn-checkbox__input--error': hasError}"
       v-bind="attrsWithoutClass"
       @change="onChange"
     >

--- a/src/components/BnCheckbox/BnCheckbox.vue
+++ b/src/components/BnCheckbox/BnCheckbox.vue
@@ -58,7 +58,6 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
   <label
     class="bn-checkbox"
     :class="[
-      `bn-checkbox--${props.color}`,
       {'bn-checkbox--error': hasError},
       {'bn-checkbox--disabled': props.disabled},
     ]"
@@ -69,7 +68,10 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
       type="checkbox"
       :name="name"
       class="bn-checkbox__input"
-      :class="{'bn-checkbox__input--error': hasError}"
+      :class="[
+        `bn-checkbox__input--${props.color}`,
+        {'bn-checkbox__input--error': hasError}
+      ]"
       v-bind="attrsWithoutClass"
       @change="onChange"
     >

--- a/src/components/BnFileInput/BnFileInput.spec.ts
+++ b/src/components/BnFileInput/BnFileInput.spec.ts
@@ -22,12 +22,12 @@ function generateFile(name: string) {
   });
 }
 
-const baseFileInput = `<BnFileInput 
+const baseFileInput = `<BnFileInput
   v-model="image"
   name="image"
 />`;
 
-const arrayFileInput = `<BnFileInput 
+const arrayFileInput = `<BnFileInput
   v-model="imagesArray"
   name="image"
   multiple
@@ -180,9 +180,10 @@ describe('BnFileInput', () => {
     const wrapper = mount(BnFileInput, { props: { name: 'image', rules: isRequired } });
     expect(wrapper.classes().includes('bn-file-input--error')).toBe(false);
     const input = wrapper.find('button');
+    expect(wrapper.find('[class$="--error"]').exists()).toBe(false);
     input.trigger('click');
     await waitForExpect(() => {
-      expect(wrapper.classes().includes('bn-file-input--error')).toBe(true);
+      expect(wrapper.find('[class$="--error"]').exists()).toBe(true);
     });
   });
 
@@ -190,10 +191,10 @@ describe('BnFileInput', () => {
     const wrapper = mount(generateExampleForm(), { props: { validationSchema: { image: isRequired } } });
     const input = wrapper.find('button');
     const inputWrapper = wrapper.find('div');
-    expect(inputWrapper.classes().includes('bn-file-input--error')).toBe(false);
+    expect(inputWrapper.find('[class$="--error"]').exists()).toBe(false);
     input.trigger('click');
     await waitForExpect(() => {
-      expect(inputWrapper.classes().includes('bn-file-input--error')).toBe(true);
+      expect(inputWrapper.find('[class$="--error"]').exists()).toBe(true);
     });
   });
 

--- a/src/components/BnFileInput/BnFileInput.styles.cjs
+++ b/src/components/BnFileInput/BnFileInput.styles.cjs
@@ -1,22 +1,16 @@
 module.exports = {
   '.bn-file-input': {
-    '&--variants-default': {
-      '.bn-file-input__wrapper': {
+    '&__wrapper': {
+      '&--variants-default': {
         '@apply form-input flex h-12 w-full items-center rounded-lg border border-gray-200 px-3 py-2 bg-banano-bg': {},
       },
-    },
-    '&--disabled': {
-      '.bn-file-input__wrapper': {
+      '&--disabled': {
         '@apply bg-gray-100 opacity-75 cursor-not-allowed': {},
       },
-    },
-    '&--custom': {
-      '.bn-file-input__wrapper': {
+      '&--custom': {
         '@apply p-0 border-0 h-auto bg-banano-bg text-banano-text-foreground': {},
       },
-    },
-    '&--error': {
-      '.bn-file-input__wrapper': {
+      '&--error': {
         '@apply border border-banano-error !important': {},
       },
     },

--- a/src/components/BnFileInput/BnFileInput.vue
+++ b/src/components/BnFileInput/BnFileInput.vue
@@ -143,17 +143,19 @@ function removeFile(file: File) {
     class="bn-file-input"
     :class="[
       `bn-file-input--${props.color}`,
-      `bn-file-input--variants-${props.variant}`,
-      {
-        'bn-file-input--disabled': props.disabled,
-        'bn-file-input--custom': $slots['default'],
-        'bn-file-input--error': meta.touched && !meta.valid,
-      }
     ]"
   >
     <component
       :is="$slots['default'] ? 'div' : 'label'"
       class="bn-file-input__wrapper"
+      :class="[
+        `bn-file-input__wrapper--variants-${props.variant}`,
+        {
+          'bn-file-input__wrapper--disabled': props.disabled,
+          'bn-file-input__wrapper--custom': $slots['default'],
+          'bn-file-input__wrapper--error': meta.touched && !meta.valid,
+        }
+      ]"
     >
       <input
         ref="fileInputRef"

--- a/src/components/BnInput/BnInput.vue
+++ b/src/components/BnInput/BnInput.vue
@@ -50,7 +50,9 @@ export default {
 <template>
   <div
     class="bn-input"
-    :class="`bn-input--${props.color} ${attrs.class ? attrs.class : ''}`"
+    :class="{
+      [attrs.class as string]: attrs.class
+    }"
   >
     <div class="bn-input__wrapper">
       <div
@@ -72,13 +74,16 @@ export default {
           :value="inputValue"
           :name="name"
           class="bn-input__input"
-          :class="{
-            'bn-input__input--icon-left': $slots['icon-left'],
-            'bn-input__input--icon-right': $slots['icon-right'],
-            'bn-input__input--prefix': $slots['prefix'],
-            'bn-input__input--suffix': $slots['suffix'],
-            'bn-input__input--error': !meta.valid && meta.touched,
-          }"
+          :class="[
+            `bn-input__input--${props.color}`,
+            {
+              'bn-input__input--icon-left': $slots['icon-left'],
+              'bn-input__input--icon-right': $slots['icon-right'],
+              'bn-input__input--prefix': $slots['prefix'],
+              'bn-input__input--suffix': $slots['suffix'],
+              'bn-input__input--error': !meta.valid && meta.touched,
+            }
+          ]"
           @input="onInput"
           @blur="handleBlur"
         >

--- a/src/components/BnListbox/BnListbox.styles.cjs
+++ b/src/components/BnListbox/BnListbox.styles.cjs
@@ -1,16 +1,14 @@
 module.exports = {
   '.bn-listbox': {
-    '&--disabled': {
-      '.bn-listbox__listbox': {
-        '@apply cursor-not-allowed bg-gray-100 opacity-75': {},
-      },
-    },
     '&__button': {
       '@apply flex h-12 w-full items-center truncate rounded-lg border border-gray-200 p-3 bg-banano-bg': {},
       '@apply text-banano-text-foreground': {},
       '@apply ui-open:outline-none focus:outline-none focus:ring ui-open:ring': {},
       '&--error': {
         '@apply border border-banano-error ring-banano-error/25 !important': {},
+      },
+      '&--disabled': {
+        '@apply cursor-not-allowed bg-gray-100 opacity-75': {},
       },
       colors: {
         '@apply ui-open:border-varColor-600 focus:border-varColor-600': {},

--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -158,10 +158,7 @@ const formValue = computed({
 </script>
 
 <template>
-  <div
-    class="bn-listbox"
-    :class="`bn-listbox--${props.color}`"
-  >
+  <div class="bn-listbox">
     <template v-if="!props.keepObjectValue">
       <template v-if="props.multiple">
         <input
@@ -190,10 +187,13 @@ const formValue = computed({
       <ListboxButton
         ref="listboxButtonRef"
         class="bn-listbox__button"
-        :class="{
-          'bn-listbox__button--error': !meta.valid && meta.touched,
-          'bn-listbox__button--disabled': props.disabled
-        }"
+        :class="[
+          `bn-listbox__button--${props.color}`,
+          {
+            'bn-listbox__button--error': !meta.valid && meta.touched,
+            'bn-listbox__button--disabled': props.disabled
+          }
+        ]"
         @blur="setTouched(true)"
       >
         <span
@@ -214,7 +214,10 @@ const formValue = computed({
               name="selected-multiple-template"
               :value="option"
             >
-              <span class="bn-listbox__tag">
+              <span
+                class="bn-listbox__tag"
+                :class="`bn-listbox__tag--${props.color}`"
+              >
                 {{ isObjectValue(option) ? option[props.optionLabel as string] : option }}
               </span>
             </slot>
@@ -254,6 +257,7 @@ const formValue = computed({
             :key="isObjectValue(option) ? (option[props.trackBy as string] as string) : option"
             :value="option"
             class="bn-listbox-options__option"
+            :class="`bn-listbox-options__option--${props.color}`"
           >
             <slot
               name="option-template"

--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -160,7 +160,7 @@ const formValue = computed({
 <template>
   <div
     class="bn-listbox"
-    :class="[`bn-listbox--${props.color}`, { 'bn-listbox--disabled': props.disabled }]"
+    :class="`bn-listbox--${props.color}`"
   >
     <template v-if="!props.keepObjectValue">
       <template v-if="props.multiple">
@@ -190,7 +190,10 @@ const formValue = computed({
       <ListboxButton
         ref="listboxButtonRef"
         class="bn-listbox__button"
-        :class="{ 'bn-listbox__button--error': !meta.valid && meta.touched }"
+        :class="{
+          'bn-listbox__button--error': !meta.valid && meta.touched,
+          'bn-listbox__button--disabled': props.disabled
+        }"
         @blur="setTouched(true)"
       >
         <span

--- a/src/components/BnTextarea/BnTextarea.spec.ts
+++ b/src/components/BnTextarea/BnTextarea.spec.ts
@@ -80,12 +80,12 @@ describe('BnTextarea', () => {
 
   it('should validate using prop rules', async () => {
     const wrapper = mount(BnTextarea, { props: { name: 'input', value: false, rules: isRequired } });
-    expect(wrapper.classes().includes('bn-textarea--error')).toBe(false);
+    expect(wrapper.find('[class$="--error"]').exists()).toBe(false);
     const input = wrapper.find('textarea');
     input.trigger('blur');
     await flushPromises();
     await waitForExpect(() => {
-      expect(wrapper.classes().includes('bn-textarea--error')).toBe(true);
+      expect(wrapper.find('[class$="--error"]').exists()).toBe(true);
     });
   });
 
@@ -93,10 +93,11 @@ describe('BnTextarea', () => {
     const wrapper = mount(generateExampleForm(), { props: { validationSchema: { input: isRequired } } });
     const inputWrapper = wrapper.getComponent(BnTextarea);
     const input = inputWrapper.find('textarea');
+    expect(inputWrapper.find('[class$="--error"]').exists()).toBe(false);
     input.trigger('blur');
     await flushPromises();
     await waitForExpect(() => {
-      expect(inputWrapper.classes().includes('bn-textarea--error')).toBe(true);
+      expect(inputWrapper.find('[class$="--error"]').exists()).toBe(true);
     });
   });
 });

--- a/src/components/BnTextarea/BnTextarea.styles.cjs
+++ b/src/components/BnTextarea/BnTextarea.styles.cjs
@@ -5,13 +5,11 @@ module.exports = {
       '@apply py-3 px-3 rounded-lg border border-gray-200 text-banano-text-foreground bg-banano-bg': {},
       '@apply placeholder:text-banano-text-muted focus:outline-none focus:ring': {},
       '@apply disabled:bg-gray-100 disabled:opacity-75 disabled:cursor-not-allowed': {},
+      '&--error': {
+        '@apply border-banano-error focus:ring-banano-error/25 !important': {},
+      },
       colors: {
         '@apply focus:border-varColor-600 focus:ring-varColor-600/25': {},
-      },
-    },
-    '&--error': {
-      '.bn-textarea__textarea': {
-        '@apply border-banano-error focus:ring-banano-error/25 !important': {},
       },
     },
     '&__error-message': {

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -44,13 +44,11 @@ const attrs = useAttrs();
 <template>
   <div
     class="bn-textarea"
-    :class="[
-      `bn-textarea--${props.color} ${attrs.class ? attrs.class : ''}`,
-      {'bn-textarea--error': !meta.valid && meta.touched},
-    ]"
+    :class="`bn-textarea--${props.color} ${attrs.class ? attrs.class : ''}`"
   >
     <textarea
       class="bn-textarea__textarea"
+      :class="{'bn-textarea__textarea--error': !meta.valid && meta.touched}"
       :value="(inputValue as string)"
       :name="name"
       @input="onInput"

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -40,6 +40,9 @@ function onInput(event: Event) {
 
 const attrs = useAttrs();
 const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
+defineOptions({
+  inheritAttrs: false,
+});
 </script>
 
 <template>

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -39,6 +39,7 @@ function onInput(event: Event) {
 }
 
 const attrs = useAttrs();
+const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
 </script>
 
 <template>
@@ -47,6 +48,7 @@ const attrs = useAttrs();
     :class="`bn-textarea--${props.color} ${attrs.class ? attrs.class : ''}`"
   >
     <textarea
+      v-bind="attrsWithoutClass"
       class="bn-textarea__textarea"
       :class="{'bn-textarea__textarea--error': !meta.valid && meta.touched}"
       :value="(inputValue as string)"

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -45,12 +45,17 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
 <template>
   <div
     class="bn-textarea"
-    :class="`bn-textarea--${props.color} ${attrs.class ? attrs.class : ''}`"
+    :class="{
+      [attrs.class as string]: attrs.class
+    }"
   >
     <textarea
       v-bind="attrsWithoutClass"
       class="bn-textarea__textarea"
-      :class="{'bn-textarea__textarea--error': !meta.valid && meta.touched}"
+      :class="[
+        `bn-textarea__textarea--${props.color}`,
+        { 'bn-textarea__textarea--error': !meta.valid && meta.touched }
+      ]"
       :value="(inputValue as string)"
       :name="name"
       @input="onInput"

--- a/src/components/BnToggle/BnToggle.spec.ts
+++ b/src/components/BnToggle/BnToggle.spec.ts
@@ -115,22 +115,23 @@ describe('BnToggle', () => {
 
   it('should validate using prop rules', async () => {
     const wrapper = mount(BnToggle, { props: { name: 'checkbox', value: false, rules: isRequired } });
-    expect(wrapper.classes().includes('bn-toggle--error')).toBe(false);
+    expect(wrapper.find('[class$="--error"]').exists()).toBe(false);
     const input = wrapper.getComponent(BnToggle);
     input.find('input').trigger('change');
     await flushPromises();
     await waitForExpect(() => {
-      expect(wrapper.classes().includes('bn-toggle--error')).toBe(true);
+      expect(wrapper.find('[class$="--error"]').exists()).toBe(true);
     });
   });
 
   it('should validate using form rules', async () => {
     const wrapper = mount(generateExampleForm(), { props: { validationSchema: { checkbox: isRequired } } });
     const input = wrapper.getComponent(BnToggle);
+    expect(input.find('[class$="--error"]').exists()).toBe(false);
     input.find('input').trigger('change');
     await flushPromises();
     await waitForExpect(() => {
-      expect(input.classes().includes('bn-toggle--error')).toBe(true);
+      expect(input.find('[class$="--error"]').exists()).toBe(true);
     });
   });
 });

--- a/src/components/BnToggle/BnToggle.styles.cjs
+++ b/src/components/BnToggle/BnToggle.styles.cjs
@@ -2,15 +2,8 @@ module.exports = {
   '.bn-toggle': {
     '&__wrapper': {
       '@apply flex items-center': {},
-    },
-    '&--disabled': {
-      '.bn-toggle__wrapper': {
+      '&--disabled': {
         '@apply cursor-not-allowed opacity-75': {},
-      },
-    },
-    '&--error': {
-      '.bn-toggle__input': {
-        '@apply border-banano-error': {},
       },
     },
     '&__toggle': {
@@ -18,25 +11,29 @@ module.exports = {
     },
     '&__track': {
       '@apply absolute left-1/2 top-1/2 h-5 w-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-gray-300': {},
-    },
-    '&__ball': {
-      '@apply absolute h-6 w-6 rounded-full border bg-white shadow': {},
-      '@apply transition-transform translate-x-0': {},
-    },
-    '&__input': {
-      '@apply sr-only': {},
-      '&:checked ~ .bn-toggle__ball': {
-        '@apply translate-x-full': {},
-      },
-      '&:checked ~ .bn-toggle__track': {
+      '&--checked': {
         colors: {
           '@apply bg-varColor-500': {},
         },
       },
-      '&:focus-visible ~ .bn-toggle__track': {
+      '&--focus-visible': {
+        '@apply ring-2 ring-offset-4': {},
         colors: {
-          '@apply ring-2 ring-offset-4 ring-varColor-500': {},
+          '@apply ring-varColor-500': {},
         },
+      },
+    },
+    '&__ball': {
+      '@apply absolute h-6 w-6 rounded-full border bg-white shadow': {},
+      '@apply transition-transform translate-x-0': {},
+      '&--checked': {
+        '@apply translate-x-full': {},
+      },
+    },
+    '&__input': {
+      '@apply sr-only': {},
+      '&--error': {
+        '@apply border-banano-error': {},
       },
     },
     '&__error-message': {

--- a/src/components/BnToggle/BnToggle.vue
+++ b/src/components/BnToggle/BnToggle.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRef, useAttrs } from 'vue';
+import { toRef, useAttrs, ref } from 'vue';
 
 type valueTypes = undefined | boolean | string | number | Record<string, unknown>;
 
@@ -50,6 +50,16 @@ function onChange(e: Event) {
   handleChange(e);
 }
 
+const isFocusedVisible = ref(false);
+function setIsFocusedVisible(event: Event) {
+  const input = event.target as HTMLInputElement;
+  if (input.matches(':focus-visible')) {
+    isFocusedVisible.value = true;
+  } else {
+    isFocusedVisible.value = false;
+  }
+}
+
 const attrs = useAttrs();
 const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
 </script>
@@ -57,13 +67,12 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
 <template>
   <div
     class="bn-toggle"
-    :class="[
-      `bn-toggle--${props.color}`,
-      {'bn-toggle--error': !meta.valid && meta.touched},
-      {'bn-toggle--disabled': props.disabled},
-    ]"
+    :class="`bn-toggle--${props.color}`"
   >
-    <label class="bn-toggle__wrapper">
+    <label
+      class="bn-toggle__wrapper"
+      :class="{ 'bn-toggle__wrapper--disabled': props.disabled }"
+    >
       <div class="bn-toggle__toggle">
         <input
           :checked="checked"
@@ -71,12 +80,24 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
           type="checkbox"
           :name="name"
           class="bn-toggle__input"
+          :class="{'bn-toggle__input--error': !meta.valid && meta.touched}"
           v-bind="attrsWithoutClass"
           :disabled="props.disabled"
           @change="onChange"
+          @focusin="setIsFocusedVisible"
+          @focusout="isFocusedVisible = false"
         >
-        <div class="bn-toggle__track" />
-        <div class="bn-toggle__ball" />
+        <div
+          class="bn-toggle__track"
+          :class="{
+            'bn-toggle__track--checked': checked,
+            'bn-toggle__track--focus-visible': isFocusedVisible,
+          }"
+        />
+        <div
+          class="bn-toggle__ball"
+          :class="{ 'bn-toggle__ball--checked': checked }"
+        />
       </div>
       <slot />
     </label>

--- a/src/components/BnToggle/BnToggle.vue
+++ b/src/components/BnToggle/BnToggle.vue
@@ -90,8 +90,8 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
         <div
           class="bn-toggle__track"
           :class="{
-            'bn-toggle__track--checked': checked,
-            'bn-toggle__track--focus-visible': isFocusedVisible,
+            [`bn-toggle__track--checked bn-toggle__track--checked-${props.color}`]: checked,
+            [`bn-toggle__track--focus-visible bn-toggle__track--focus-visible-${props.color}`]: isFocusedVisible,
           }"
         />
         <div

--- a/src/components/Btn/Btn.styles.cjs
+++ b/src/components/Btn/Btn.styles.cjs
@@ -5,41 +5,29 @@ module.exports = {
     '&--sizes-xs': {
       '@apply text-xs': {},
       '@apply px-3 py-1.5': {},
-      '.bn-btn__loading': {
-        '@apply w-4 h-4': {},
-      },
     },
     '&--sizes-sm': {
       '@apply text-sm': {},
       '@apply px-3 py-1.5': {},
-      '.bn-btn__loading': {
-        '@apply w-4 h-4': {},
-      },
     },
     '&--sizes-md': {
       '@apply text-base': {},
       '@apply px-4 py-2': {},
-      '.bn-btn__loading': {
-        '@apply w-5 h-5': {},
-      },
     },
     '&--sizes-lg': {
       '@apply text-lg': {},
       '@apply px-6 py-3': {},
-      '.bn-btn__loading': {
-        '@apply w-6 h-6': {},
-      },
     },
     '&--shapes-circle': {
       '@apply rounded-full': {},
       '@apply !p-0 leading-tight': {},
-      '&.bn-btn--sizes-sm': {
+      '&-sm': {
         '@apply w-6 h-6': {},
       },
-      '&.bn-btn--sizes-md': {
+      '&-md': {
         '@apply w-8 h-8': {},
       },
-      '&.bn-btn--sizes-lg': {
+      '&-lg': {
         '@apply w-10 h-10': {},
       },
     },
@@ -64,7 +52,7 @@ module.exports = {
       '@apply border border-solid': {},
       '@apply focus:outline-none focus:ring-2': {},
       colors: {
-        '@apply text-varColor-600 bg-transparent': {},
+        '@apply text-varColor-600': {},
         '@apply border-varColor-600': {},
         '@apply hover:bg-varColor-100': {},
 
@@ -76,7 +64,7 @@ module.exports = {
       '@apply border border-transparent': {},
       '@apply focus:outline-none': {},
       colors: {
-        '@apply text-varColor-600 bg-transparent': {},
+        '@apply text-varColor-600': {},
         '@apply hover:text-varColor-400': {},
 
         '@apply focus:text-varColor-400': {},
@@ -92,6 +80,18 @@ module.exports = {
       '@apply animate-spin mr-3': {},
       '&--no-content': {
         '@apply mr-0': {},
+      },
+      '&--sizes-xs': {
+        '@apply w-4 h-4': {},
+      },
+      '&--sizes-sm': {
+        '@apply w-4 h-4': {},
+      },
+      '&--sizes-md': {
+        '@apply w-5 h-5': {},
+      },
+      '&--sizes-lg': {
+        '@apply w-6 h-6': {},
       },
     },
     '&__loading-circle': {

--- a/src/components/Btn/Btn.vue
+++ b/src/components/Btn/Btn.vue
@@ -39,6 +39,7 @@ const tag = computed(() => {
     :class="[
       `bn-btn--sizes-${props.size}`,
       `bn-btn--shapes-${props.shape}`,
+      `bn-btn--shapes-${props.shape}-${props.size}`,
       `bn-btn--variants-${props.variant}`,
       `bn-btn--${props.color}`,
     ]"
@@ -54,6 +55,7 @@ const tag = computed(() => {
         <svg
           v-if="loading"
           class="bn-btn__loading"
+          :class="`bn-btn__loading--sizes-${props.size}`"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -85,6 +87,7 @@ const tag = computed(() => {
     <template v-else>
       <svg
         class="bn-btn__loading bn-btn__loading--no-content"
+        :class="`bn-btn__loading--sizes-${props.size}`"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/src/components/Btn/Btn.vue
+++ b/src/components/Btn/Btn.vue
@@ -41,6 +41,7 @@ const tag = computed(() => {
       `bn-btn--shapes-${props.shape}`,
       `bn-btn--shapes-${props.shape}-${props.size}`,
       `bn-btn--variants-${props.variant}`,
+      `bn-btn--variants-${props.variant}-${props.color}`,
       `bn-btn--${props.color}`,
     ]"
   >

--- a/src/tailwind/index.cjs
+++ b/src/tailwind/index.cjs
@@ -46,11 +46,19 @@ function parseStyles(obj, colors, componentClass, elementClasses = []) {
     const newElementClasses = [...elementClasses];
     if (key === 'colors') {
       const colorClasses = parseColors(value, colors);
-      const isElement = newElementClasses[1] && newElementClasses[1].startsWith('&__');
       const newElementClass = newElementClasses.join('').replace(/&/g, '');
+      const isBlock = !newElementClass.includes('--') && !newElementClass.includes('__');
+      const isElement = !newElementClass.includes('--') && newElementClass.includes('__');
+      const isModifier = newElementClass.includes('--');
 
       Object.keys(colorClasses).forEach((color) => {
-        prev[`@at-root ${componentClass}--${color}${isElement ? ' ' : ''}${newElementClass}`] = parseStyles(colorClasses[color], colors, componentClass, newElementClasses);
+        let colorClass;
+        if (isBlock || isElement) {
+          colorClass = `&--${color}`;
+        } else if (isModifier) {
+          colorClass = `&-${color}`;
+        }
+        prev[colorClass] = parseStyles(colorClasses[color], colors, componentClass, newElementClasses);
       });
     } else {
       if (!key.startsWith('@')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,7 +156,12 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.5.tgz#337062363436a893a2d22faa60be5bb37091c83c"
   integrity sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==
 
-"@babel/parser@^7.20.15", "@babel/parser@^7.21.3", "@babel/parser@^7.21.4":
+"@babel/parser@^7.20.15", "@babel/parser@^7.21.3":
+  version "7.22.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.7.tgz#df8cf085ce92ddbdbf668a7f186ce848c9036cae"
+  integrity sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==
+
+"@babel/parser@^7.21.4":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.5.tgz#721fd042f3ce1896238cf1b341c77eb7dee7dbea"
   integrity sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==
@@ -587,7 +592,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@jridgewell/sourcemap-codec@^1.4.13":
+"@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -3272,11 +3277,11 @@ magic-string@^0.29.0:
     "@jridgewell/sourcemap-codec" "^1.4.13"
 
 magic-string@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.0.tgz#fd58a4748c5c4547338a424e90fa5dd17f4de529"
-  integrity sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==
+  version "0.30.2"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.2.tgz#dcf04aad3d0d1314bc743d076c50feb29b3c7aca"
+  integrity sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==
   dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.13"
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 markdown-it-anchor@^8.6.2:
   version "8.6.7"
@@ -3422,12 +3427,7 @@ muggle-string@^0.3.1:
   resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.3.1.tgz#e524312eb1728c63dd0b2ac49e3282e6ed85963a"
   integrity sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==
 
-nanoid@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
-
-nanoid@^3.3.6:
+nanoid@^3.3.4, nanoid@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
@@ -3728,11 +3728,11 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.1.10:
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
-  integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
+  version "8.4.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
+  integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==
   dependencies:
-    nanoid "^3.3.4"
+    nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 


### PR DESCRIPTION
## Context

- Banano is a component library for use in our projects
- A feature we're going to include is a `classes`, which is an object with keys that correspond to internal elements ofo a component, and allows to include new classes to those elements. This classes don't completely replace previous default styles, but should be able to override them if there is some overlap
- Developing this feature, we realized that there were some default styles that were added with selectors that had a higher specificity than a single class, so those styles were not being overriden

## Changes
This PR flattens all selectors of default styles to just be single classes, so that classes prop can override them.
- Every style applied with a nested selector, or a selector that checked more than one class, were changed to only need one class. This required some classes to be moved from the parent to the child
  - For listbox, a related fix was added: the disabled styles were being applied to the wrong element
  - Some tests that checked for error classes failed, I changed it to check for error class in any element within the component
- Color classes were also unnested. The previous behavior required a color class in the root element of the component, and a `colors:` key in the `.cjs`, in any sub element or modifier (or the block itself). Now the processing of these `colors:` are changed in the `tailwind/index.cjs`: it requires a color modifier class in the element itself. When using a `colors:` inside a modifier class, just one `-` is added, as BEM specifies that there should only be one modifier in a class name
