### PR TITLE
style(BnListbox): add style when is navigated by keyboard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Context
+
+- Banano is a component library for use in platanus projects
+
+
+## Changes
+

--- a/src/components/BnListbox/BnListbox.styles.cjs
+++ b/src/components/BnListbox/BnListbox.styles.cjs
@@ -43,9 +43,9 @@ module.exports = {
   '.bn-listbox-options': {
     '@apply fixed max-h-60 w-full overflow-auto rounded-lg border border-gray-200 bg-white': {},
     '&__option': {
-      '@apply flex h-12 items-center p-3 ui-selected:text-white hover:text-white': {},
+      '@apply flex h-12 items-center p-3 ui-selected:text-white hover:text-white ui-active:text-white': {},
       colors: {
-        '@apply hover:bg-varColor-600 ui-selected:bg-varColor-600': {},
+        '@apply hover:bg-varColor-600 ui-selected:bg-varColor-600 ui-active:bg-varColor-600': {},
       },
     },
     '&__option-text': {


### PR DESCRIPTION
## Context

- Banano is a component library for use in our projects
- We made a listbox component with its basics interactions, but when you navigate It with arrows, It does not shows any feedback of what is happening.


## Changes

* A `ui:active` selector has been added to the listbox styles to be activated when `headless-ui` calificates a option as active.
* Also I added a PR template for futures PRs.

