### PR TITLE
feat(): transform all useField values to refs

### DIFF
--- a/src/components/BnInput/BnInput.vue
+++ b/src/components/BnInput/BnInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRef, useAttrs } from 'vue';
+import { toRefs, useAttrs } from 'vue';
 
 interface Props {
   modelValue?: string | number
@@ -17,7 +17,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{(e: 'update:modelValue', value: number | string): void}>();
 
-const name = toRef(props, 'name');
+const { name, rules } = toRefs(props);
 
 const {
   value: inputValue,
@@ -25,9 +25,8 @@ const {
   handleChange,
   meta,
   errorMessage,
-} = useField(name, props.rules, {
+} = useField(name, rules, {
   initialValue: props.modelValue,
-  valueProp: props.modelValue,
   validateOnMount: true,
 });
 

--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRef, ref, ComponentPublicInstance, watchEffect, computed } from 'vue';
+import { ref, ComponentPublicInstance, watchEffect, computed, toRefs } from 'vue';
 import { useElementBounding } from '@vueuse/core';
 import {
   Listbox,
@@ -61,7 +61,7 @@ const emit = defineEmits<{
   ): void
 }>();
 
-const name = toRef(props, 'name');
+const { name, rules } = toRefs(props);
 
 function parseValue(value: InputValue | InputValue[]) {
   if (!value) {
@@ -112,7 +112,7 @@ function unparseValue(value: InputValue | InputValue[]) {
 
 const parsedValue = computed(() => parseValue(props.modelValue));
 
-const { handleChange, value, meta, setTouched, errorMessage } = useField<InputValue | InputValue[]>(name, props.rules, {
+const { handleChange, value, meta, setTouched, errorMessage } = useField<InputValue | InputValue[]>(name, rules, {
   initialValue: props.modelValue,
   validateOnMount: true,
 });

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRef, useAttrs } from 'vue';
+import { toRefs, useAttrs } from 'vue';
 
 interface Props {
   modelValue?: string | number
@@ -18,7 +18,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{(e: 'update:modelValue', value: number | string): void}>();
 
-const name = toRef(props, 'name');
+const { name, rules } = toRefs(props);
 
 const {
   value: inputValue,
@@ -26,9 +26,8 @@ const {
   handleChange,
   meta,
   errorMessage,
-} = useField(name, props.rules, {
+} = useField(name, rules, {
   initialValue: props.modelValue,
-  valueProp: props.modelValue,
   validateOnMount: true,
 });
 

--- a/src/components/BnToggle/BnToggle.vue
+++ b/src/components/BnToggle/BnToggle.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRef, useAttrs, ref } from 'vue';
+import { useAttrs, ref, toRefs } from 'vue';
 
 type valueTypes = undefined | boolean | string | number | Record<string, unknown>;
 
@@ -23,11 +23,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{(e: 'update:modelValue', value: valueTypes | valueTypes[]): void}>();
 
-const name = toRef(props, 'name');
+const { name, rules, value } = toRefs(props);
 
-const { handleChange, checked, meta, setTouched, errorMessage } = useField(props.name, props.rules, {
+const { handleChange, checked, meta, setTouched, errorMessage } = useField(name, rules, {
   type: 'checkbox',
-  checkedValue: props.value,
+  checkedValue: value,
   initialValue: props.modelValue,
   validateOnMount: true,
 });


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects
- vee-validate's useField needs [reactive properties to work](https://vee-validate.logaretm.com/v4/guide/composition-api/caveats/#function-field-names-with-usefield)


## Changes
* All the properties used in useField are transformed using `toRefs`. Initial value doesn't seem to need to be reactive, in [the Field component](https://github.com/logaretm/vee-validate/blob/main/packages/vee-validate/src/Field.ts#L288-L296) it's used directly.