### PR TITLE
Feat/expose listeners

### DIFF
--- a/src/components/BnCheckbox/BnCheckbox.vue
+++ b/src/components/BnCheckbox/BnCheckbox.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRefs, useAttrs, computed } from 'vue';
+import { toRefs, computed } from 'vue';
 import { type ComponentClassType } from '../../types/class';
+import useAttrsWithoutClass from '../../composables/useAttrsWithoutClass';
 
 interface ClassesProp {
   input?: ComponentClassType,
@@ -29,6 +30,9 @@ const props = withDefaults(defineProps<Props>(), {
   uncheckedValue: undefined,
   classes: () => ({}),
 });
+
+const { attrClass, attrsWithoutClass } = useAttrsWithoutClass();
+defineOptions({ inheritAttrs: false });
 
 const { name, uncheckedValue, rules, value } = toRefs(props);
 
@@ -58,8 +62,6 @@ function onChange(e: Event) {
   }
 }
 
-const attrs = useAttrs();
-const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
 </script>
 
 <template>
@@ -68,6 +70,7 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
     :class="[
       {'bn-checkbox--error': hasError},
       {'bn-checkbox--disabled': props.disabled},
+      attrClass,
     ]"
   >
     <input

--- a/src/components/BnFileInput/BnFileInput.spec.ts
+++ b/src/components/BnFileInput/BnFileInput.spec.ts
@@ -179,9 +179,9 @@ describe('BnFileInput', () => {
   it('should validate using prop rules', async () => {
     const wrapper = mount(BnFileInput, { props: { name: 'image', rules: isRequired } });
     expect(wrapper.classes().includes('bn-file-input--error')).toBe(false);
-    const input = wrapper.find('button');
+    const input = wrapper.find('label');
     expect(wrapper.find('[class$="--error"]').exists()).toBe(false);
-    input.trigger('click');
+    await input.trigger('blur');
     await waitForExpect(() => {
       expect(wrapper.find('[class$="--error"]').exists()).toBe(true);
     });
@@ -189,10 +189,10 @@ describe('BnFileInput', () => {
 
   it('should validate using form rules', async () => {
     const wrapper = mount(generateExampleForm(), { props: { validationSchema: { image: isRequired } } });
-    const input = wrapper.find('button');
+    const input = wrapper.find('label');
     const inputWrapper = wrapper.find('div');
     expect(inputWrapper.find('[class$="--error"]').exists()).toBe(false);
-    input.trigger('click');
+    input.trigger('blur');
     await waitForExpect(() => {
       expect(inputWrapper.find('[class$="--error"]').exists()).toBe(true);
     });
@@ -221,6 +221,40 @@ describe('BnFileInput', () => {
 
     await waitForExpect(() => {
       expect(wrapper.vm.imagesArray).toStrictEqual([file]);
+    });
+  });
+
+  describe('with default slot', () => {
+    it('should trigger focus event', async () => {
+      const wrapper = mount(BnFileInput, { props: { name: 'image' } });
+      await wrapper.find('label').trigger('focus');
+      await waitForExpect(() => {
+        expect(wrapper.emitted('focus')).toBeTruthy();
+      });
+    });
+    it('should trigger blur event', async () => {
+      const wrapper = mount(BnFileInput, { props: { name: 'image' } });
+      await wrapper.find('label').trigger('blur');
+      await waitForExpect(() => {
+        expect(wrapper.emitted('blur')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('with avatar slot', () => {
+    it('should trigger focus event', async () => {
+      const wrapper = mount(BnFileInput, { props: { name: 'image', variant: 'avatar' } });
+      await wrapper.find('button').trigger('focus');
+      await waitForExpect(() => {
+        expect(wrapper.emitted('focus')).toBeTruthy();
+      });
+    });
+    it('should trigger blur event', async () => {
+      const wrapper = mount(BnFileInput, { props: { name: 'image', variant: 'avatar' } });
+      await wrapper.find('button').trigger('blur');
+      await waitForExpect(() => {
+        expect(wrapper.emitted('blur')).toBeTruthy();
+      });
     });
   });
 });

--- a/src/components/BnFileInput/BnFileInput.styles.cjs
+++ b/src/components/BnFileInput/BnFileInput.styles.cjs
@@ -18,7 +18,7 @@ module.exports = {
       '@apply hidden': {},
     },
     '&__button': {
-      '@apply mr-2 shrink-0 cursor-pointer': {},
+      '@apply mr-2 shrink-0 cursor-pointer outline-none': {},
     },
     '&__label': {
       '@apply w-full overflow-hidden text-sm text-banano-text-foreground': {},

--- a/src/components/BnInput/BnInput.vue
+++ b/src/components/BnInput/BnInput.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRefs, useAttrs } from 'vue';
+import { toRefs } from 'vue';
 import { type ComponentClassType } from '../../types/class';
+import useAttrsWithoutClass from '../../composables/useAttrsWithoutClass';
 
 interface ClassesProp {
   input?: ComponentClassType,
@@ -24,6 +25,9 @@ const props = withDefaults(defineProps<Props>(), {
   classes: () => ({}),
 });
 
+const { attrClass, attrsWithoutClass } = useAttrsWithoutClass();
+defineOptions({ inheritAttrs: false });
+
 const { name, rules } = toRefs(props);
 
 const {
@@ -38,22 +42,12 @@ const {
   syncVModel: true,
 });
 
-const attrs = useAttrs();
-const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <template>
   <div
     class="bn-input"
-    :class="{
-      [attrs.class as string]: attrs.class
-    }"
+    :class="attrClass"
   >
     <div class="bn-input__wrapper">
       <div

--- a/src/components/BnListbox/BnListbox.spec.ts
+++ b/src/components/BnListbox/BnListbox.spec.ts
@@ -1,12 +1,11 @@
-import flushPromises from 'flush-promises';
 import waitForExpect from 'wait-for-expect';
 import { defineComponent } from 'vue';
 import { Form } from 'vee-validate';
 import { ListboxOption } from '@headlessui/vue';
 import { mount } from '@vue/test-utils';
-import BnListbox from './BnListbox.vue';
+import BnListbox, { type InputValue } from './BnListbox.vue';
 
-function isRequired(val: string) {
+function isRequired(val: InputValue | InputValue[]) {
   if (!val) {
     return 'This field is required';
   }

--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -19,15 +19,14 @@ interface ClassesProp {
   option?: ComponentClassType,
 }
 
-type InputValue = number | string | Record<string, unknown> | undefined;
+export type InputValue = number | string | Record<string, unknown> | undefined;
 
 interface Props {
   modelValue?: InputValue | InputValue[]
   options: string[] | Record<string, unknown>[]
   name: string
   color?: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rules?: RuleExpression<any>
+  rules?: RuleExpression<InputValue | InputValue[]>
   disabled?: boolean
   multiple?: boolean
   trackBy?: string
@@ -63,6 +62,11 @@ function isObjectOptions(value: InputValue[]): value is Record<string, unknown>[
 function isMultipleValue(value: InputValue | InputValue[]): value is InputValue[] {
   return props.multiple;
 }
+
+const emit = defineEmits<{
+  (e: 'focus', event: Event): void,
+  (e: 'blur', event: Event): void,
+}>();
 
 const { name, rules } = toRefs(props);
 
@@ -165,8 +169,12 @@ const formValue = computed({
     onUpdate(val);
   },
 });
-</script>
 
+function blur(e: Event) {
+  setTouched(true);
+  emit('blur', e);
+}
+</script>
 <template>
   <div class="bn-listbox">
     <template v-if="!props.keepObjectValue">
@@ -205,7 +213,8 @@ const formValue = computed({
           },
           props.classes.button
         ]"
-        @blur="setTouched(true)"
+        @blur="blur"
+        @focus="emit('focus', $event)"
       >
         <span
           v-if="placeholder && isEmpty(parsedValue)"

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { toRefs, useAttrs } from 'vue';
+import { toRefs } from 'vue';
+import useAttrsWithoutClass from '../../composables/useAttrsWithoutClass';
 import { type ComponentClassType } from '../../types/class';
 
 interface ClassesProp {
@@ -23,6 +24,9 @@ const props = withDefaults(defineProps<Props>(), {
   classes: () => ({}),
 });
 
+const { attrClass, attrsWithoutClass } = useAttrsWithoutClass();
+defineOptions({ inheritAttrs: false });
+
 const { name, rules } = toRefs(props);
 
 const {
@@ -37,19 +41,12 @@ const {
   syncVModel: true,
 });
 
-const attrs = useAttrs();
-const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
-defineOptions({
-  inheritAttrs: false,
-});
 </script>
 
 <template>
   <div
     class="bn-textarea"
-    :class="{
-      [attrs.class as string]: attrs.class
-    }"
+    :class="attrClass"
   >
     <textarea
       v-bind="attrsWithoutClass"

--- a/src/components/BnToggle/BnToggle.spec.ts
+++ b/src/components/BnToggle/BnToggle.spec.ts
@@ -3,9 +3,9 @@ import waitForExpect from 'wait-for-expect';
 import { defineComponent } from 'vue';
 import { Form } from 'vee-validate';
 import { mount } from '@vue/test-utils';
-import BnToggle, { type valueTypes } from './BnToggle.vue';
+import BnToggle, { type ValueTypes } from './BnToggle.vue';
 
-function isRequired(val: valueTypes | valueTypes[]) {
+function isRequired(val: ValueTypes | ValueTypes[]) {
   if (!val) {
     return 'This field is required';
   }

--- a/src/components/BnToggle/BnToggle.vue
+++ b/src/components/BnToggle/BnToggle.vue
@@ -1,20 +1,22 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { useAttrs, ref, toRefs } from 'vue';
+import { toRefs, ref } from 'vue';
 import { type ComponentClassType } from '../../types/class';
+import useAttrsWithoutClass from '../../composables/useAttrsWithoutClass';
 
 interface ClassesProp {
   ball?: ComponentClassType,
   track?: ComponentClassType,
 }
-export type valueTypes = undefined | boolean | string | number | Record<string, unknown>;
+
+export type ValueTypes = undefined | boolean | string | number | Record<string, unknown>;
 
 interface Props {
-  modelValue?: valueTypes | valueTypes[],
-  value: valueTypes,
+  modelValue?: ValueTypes | ValueTypes[],
+  value: ValueTypes,
   name: string,
   color?: string,
-  rules?: RuleExpression<valueTypes | valueTypes[]>,
+  rules?: RuleExpression<ValueTypes | ValueTypes[]>,
   disabled?: boolean,
   classes?: ClassesProp,
 }
@@ -27,6 +29,9 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   classes: () => ({}),
 });
+
+const { attrClass, attrsWithoutClass } = useAttrsWithoutClass();
+defineOptions({ inheritAttrs: false });
 
 const { name, rules, value } = toRefs(props);
 
@@ -65,14 +70,12 @@ function setIsFocusedVisible(event: Event) {
   }
 }
 
-const attrs = useAttrs();
-const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
 </script>
 
 <template>
   <div
     class="bn-toggle"
-    :class="`bn-toggle--${props.color}`"
+    :class="[`bn-toggle--${props.color}`, attrClass]"
   >
     <label
       class="bn-toggle__wrapper"

--- a/src/composables/useAttrsWithoutClass.spec.ts
+++ b/src/composables/useAttrsWithoutClass.spec.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import useAttrsWithoutClass from './useAttrsWithoutClass';
+
+describe('useAttrsWithoutClass', () => {
+  it('should return attrs without class', () => {
+    const component = defineComponent({
+      inheritAttrs: false,
+      setup() {
+        const { attrClass, attrsWithoutClass } = useAttrsWithoutClass();
+
+        return { attrClass, attrsWithoutClass };
+      },
+      template:
+      `<div :class="attrClass">
+        <input v-bind="attrsWithoutClass" />
+      </div>`,
+    });
+    const wrapper = mount(component, { props: { class: 'test', disabled: true } });
+    expect(wrapper.classes()).toContain('test');
+    const input = wrapper.find('input');
+    expect(input.element.disabled).toEqual(true);
+  });
+});

--- a/src/composables/useAttrsWithoutClass.ts
+++ b/src/composables/useAttrsWithoutClass.ts
@@ -1,0 +1,8 @@
+import { useAttrs } from 'vue';
+
+export default function useAttrsWithoutClass() {
+  const attrs = useAttrs();
+  const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
+
+  return { attrClass: attrs.class, attrsWithoutClass };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['./src/components/**/*.spec.ts'],
+    include: ['./src/components/**/*.spec.ts', './src/composables/**/*.spec.ts'],
     globals: true,
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Context

* Banano is a component library for use in platanus projects
* At the moment, all the components are working, but not all of them are emiting the classics events as `focus` or `blur`. 


## Changes

* I made a `composable` called `useAttrsWithoutClass` to get the rest of attrs and use it in all the components. This includes it`s corresponding test.
* The composable was used in the components: `BnCheckbox`, `BnInput`, `BnToggle`, `BnTextArea`, `BnFileInput`.
* Also a typescript `any` inside the same components was fixed.
* `BnListbox` and `BnFileInput` components now emits a custom `focus` and `blur` events.
* Finally I made the entire `fileInput` component focuseable instead only the inside button. 

Events where not added to `BnModal` and `BnPaginator` components.

https://github.com/platanus/banano/assets/26394880/8fd2a691-7917-4168-b17b-795fa58f82d9


