### PR TITLE
feat(): use vee-validate's syncVModel to handle v-model

### DIFF
--- a/src/components/BnCheckbox/BnCheckbox.spec.ts
+++ b/src/components/BnCheckbox/BnCheckbox.spec.ts
@@ -65,6 +65,7 @@ function generateExampleForm(useArray?: boolean) {
     template: `
       <Form @submit="submit" :validation-schema="validationSchema">
         ${useArray ? arrayCheckboxes : baseCheckbox}
+        <button type="submit">Submit</button>
       </Form>
     `,
   });
@@ -80,7 +81,7 @@ describe('BnCheckbox', () => {
   it('v-model should work', async () => {
     const wrapper = mount(generateExampleForm());
     const input = wrapper.getComponent(BnCheckbox);
-    input.find('input').setValue();
+    await input.find('input').setValue();
 
     expect(wrapper.vm.checked).toBe('checked');
   });
@@ -118,7 +119,6 @@ describe('BnCheckbox', () => {
     expect(wrapper.classes().includes('bn-checkbox--error')).toBe(false);
     const input = wrapper.getComponent(BnCheckbox);
     input.find('input').trigger('change');
-    await flushPromises();
     await waitForExpect(() => {
       expect(wrapper.classes().includes('bn-checkbox--error')).toBe(true);
     });
@@ -127,8 +127,7 @@ describe('BnCheckbox', () => {
   it('should validate using form rules', async () => {
     const wrapper = mount(generateExampleForm(), { props: { validationSchema: { checkbox: isRequired } } });
     const input = wrapper.getComponent(BnCheckbox);
-    input.find('input').trigger('change');
-    await flushPromises();
+    wrapper.find('form').trigger('submit');
     await waitForExpect(() => {
       expect(input.classes().includes('bn-checkbox--error')).toBe(true);
     });

--- a/src/components/BnCheckbox/BnCheckbox.vue
+++ b/src/components/BnCheckbox/BnCheckbox.vue
@@ -23,8 +23,6 @@ const props = withDefaults(defineProps<Props>(), {
   uncheckedValue: undefined,
 });
 
-const emit = defineEmits<{ (e: 'update:modelValue', value: ValueType | ValueType[]): void }>();
-
 const { name, uncheckedValue, rules, value } = toRefs(props);
 
 const { handleChange, checked, meta, setTouched } = useField(name, rules, {
@@ -32,6 +30,7 @@ const { handleChange, checked, meta, setTouched } = useField(name, rules, {
   checkedValue: value,
   initialValue: props.modelValue,
   uncheckedValue,
+  syncVModel: true,
 });
 const hasError = computed(() => !meta.valid && meta.touched);
 
@@ -46,11 +45,10 @@ function onChange(e: Event) {
     } else {
       newValue.splice(newValue.indexOf(props.value), 1);
     }
-    emit('update:modelValue', newValue);
+    handleChange(newValue);
   } else {
-    emit('update:modelValue', input.checked ? props.value : undefined);
+    handleChange(checked?.value ? value : undefined);
   }
-  handleChange(e);
 }
 
 const attrs = useAttrs();

--- a/src/components/BnInput/BnInput.spec.ts
+++ b/src/components/BnInput/BnInput.spec.ts
@@ -5,7 +5,7 @@ import { Form } from 'vee-validate';
 import { mount } from '@vue/test-utils';
 import BnInput from './BnInput.vue';
 
-function isRequired(val: string) {
+function isRequired(val: string | number) {
   if (!val) {
     return 'This field is required';
   }
@@ -59,7 +59,7 @@ describe('BnInput', () => {
   it('v-model should work', async () => {
     const wrapper = mount(generateExampleForm());
     const input = wrapper.getComponent(BnInput);
-    input.find('input').setValue('Hello World!');
+    await input.find('input').setValue('Hello World!');
 
     expect(wrapper.vm.input).toBe('Hello World!');
   });
@@ -83,7 +83,6 @@ describe('BnInput', () => {
     expect(wrapper.classes().includes('bn-input__input--error')).toBe(false);
     const input = wrapper.find('input');
     input.trigger('blur');
-    await flushPromises();
     await waitForExpect(() => {
       expect(input.classes().includes('bn-input__input--error')).toBe(true);
     });
@@ -93,7 +92,6 @@ describe('BnInput', () => {
     const wrapper = mount(generateExampleForm(), { props: { validationSchema: { input: isRequired } } });
     const input = wrapper.getComponent(BnInput).find('input');
     input.trigger('blur');
-    await flushPromises();
     await waitForExpect(() => {
       expect(input.classes().includes('bn-input__input--error')).toBe(true);
     });

--- a/src/components/BnInput/BnInput.vue
+++ b/src/components/BnInput/BnInput.vue
@@ -6,7 +6,7 @@ interface Props {
   modelValue?: string | number
   name: string
   color?: string
-  rules?: RuleExpression<unknown>,
+  rules?: RuleExpression<string | number>,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -14,8 +14,6 @@ const props = withDefaults(defineProps<Props>(), {
   color: 'banano-base',
   rules: undefined,
 });
-
-const emit = defineEmits<{(e: 'update:modelValue', value: number | string): void}>();
 
 const { name, rules } = toRefs(props);
 
@@ -28,13 +26,8 @@ const {
 } = useField(name, rules, {
   initialValue: props.modelValue,
   validateOnMount: true,
+  syncVModel: true,
 });
-
-function onInput(event: Event) {
-  inputValue.value = (event.target as HTMLInputElement).value;
-  handleChange(event, true);
-  emit('update:modelValue', (event.target as HTMLInputElement).value);
-}
 
 const attrs = useAttrs();
 const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
@@ -83,7 +76,7 @@ export default {
               'bn-input__input--error': !meta.valid && meta.touched,
             }
           ]"
-          @input="onInput"
+          @input="handleChange"
           @blur="handleBlur"
         >
         <div

--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -54,13 +54,6 @@ function isMultipleValue(value: InputValue | InputValue[]): value is InputValue[
   return props.multiple;
 }
 
-const emit = defineEmits<{
-  (
-    e: 'update:modelValue',
-    value: InputValue | InputValue[],
-  ): void
-}>();
-
 const { name, rules } = toRefs(props);
 
 function parseValue(value: InputValue | InputValue[]) {
@@ -115,6 +108,7 @@ const parsedValue = computed(() => parseValue(props.modelValue));
 const { handleChange, value, meta, setTouched, errorMessage } = useField<InputValue | InputValue[]>(name, rules, {
   initialValue: props.modelValue,
   validateOnMount: true,
+  syncVModel: true,
 });
 
 const listboxButtonRef = ref<ComponentPublicInstance>();
@@ -144,7 +138,6 @@ watchEffect(() => {
 function onUpdate(val: InputValue | InputValue[]) {
   const unparsedValue = unparseValue(val);
   handleChange(unparsedValue);
-  emit('update:modelValue', unparsedValue);
 }
 
 const formValue = computed({

--- a/src/components/BnTextarea/BnTextarea.spec.ts
+++ b/src/components/BnTextarea/BnTextarea.spec.ts
@@ -1,11 +1,10 @@
-import flushPromises from 'flush-promises';
 import waitForExpect from 'wait-for-expect';
 import { defineComponent } from 'vue';
 import { Form } from 'vee-validate';
 import { mount } from '@vue/test-utils';
 import BnTextarea from './BnTextarea.vue';
 
-function isRequired(val: string) {
+function isRequired(val: string | number) {
   if (!val) {
     return 'This field is required';
   }
@@ -59,7 +58,7 @@ describe('BnTextarea', () => {
   it('v-model should work', async () => {
     const wrapper = mount(generateExampleForm());
     const input = wrapper.getComponent(BnTextarea);
-    input.find('textarea').setValue('Hello World!');
+    await input.find('textarea').setValue('Hello World!');
 
     expect(wrapper.vm.input).toBe('Hello World!');
   });
@@ -70,7 +69,6 @@ describe('BnTextarea', () => {
     input.find('textarea').setValue('Hello World!');
     wrapper.find('form').trigger('submit');
 
-    await flushPromises();
     await waitForExpect(() => {
       expect(wrapper.vm.submittedValues).toStrictEqual({
         input: 'Hello World!',
@@ -83,7 +81,6 @@ describe('BnTextarea', () => {
     expect(wrapper.find('[class$="--error"]').exists()).toBe(false);
     const input = wrapper.find('textarea');
     input.trigger('blur');
-    await flushPromises();
     await waitForExpect(() => {
       expect(wrapper.find('[class$="--error"]').exists()).toBe(true);
     });
@@ -95,7 +92,6 @@ describe('BnTextarea', () => {
     const input = inputWrapper.find('textarea');
     expect(inputWrapper.find('[class$="--error"]').exists()).toBe(false);
     input.trigger('blur');
-    await flushPromises();
     await waitForExpect(() => {
       expect(inputWrapper.find('[class$="--error"]').exists()).toBe(true);
     });

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -6,7 +6,7 @@ interface Props {
   modelValue?: string | number
   name: string
   color?: string
-  rules?: RuleExpression<unknown>,
+  rules?: RuleExpression<string | number>,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -15,8 +15,6 @@ const props = withDefaults(defineProps<Props>(), {
   color: 'banano-base',
   rules: undefined,
 });
-
-const emit = defineEmits<{(e: 'update:modelValue', value: number | string): void}>();
 
 const { name, rules } = toRefs(props);
 
@@ -29,13 +27,8 @@ const {
 } = useField(name, rules, {
   initialValue: props.modelValue,
   validateOnMount: true,
+  syncVModel: true,
 });
-
-function onInput(event: Event) {
-  inputValue.value = (event.target as HTMLInputElement).value;
-  handleChange(event, true);
-  emit('update:modelValue', (event.target as HTMLInputElement).value);
-}
 
 const attrs = useAttrs();
 const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]) => key !== 'class'));
@@ -60,7 +53,7 @@ defineOptions({
       ]"
       :value="(inputValue as string)"
       :name="name"
-      @input="onInput"
+      @input="handleChange"
       @blur="handleBlur"
     />
     <slot

--- a/src/components/BnToggle/BnToggle.spec.ts
+++ b/src/components/BnToggle/BnToggle.spec.ts
@@ -3,9 +3,9 @@ import waitForExpect from 'wait-for-expect';
 import { defineComponent } from 'vue';
 import { Form } from 'vee-validate';
 import { mount } from '@vue/test-utils';
-import BnToggle from './BnToggle.vue';
+import BnToggle, { type valueTypes } from './BnToggle.vue';
 
-function isRequired(val: string) {
+function isRequired(val: valueTypes | valueTypes[]) {
   if (!val) {
     return 'This field is required';
   }
@@ -80,7 +80,7 @@ describe('BnToggle', () => {
   it('v-model should work', async () => {
     const wrapper = mount(generateExampleForm());
     const input = wrapper.getComponent(BnToggle);
-    input.find('input').setValue();
+    await input.find('input').setValue();
 
     expect(wrapper.vm.checked).toBe('checked');
   });
@@ -118,7 +118,6 @@ describe('BnToggle', () => {
     expect(wrapper.find('[class$="--error"]').exists()).toBe(false);
     const input = wrapper.getComponent(BnToggle);
     input.find('input').trigger('change');
-    await flushPromises();
     await waitForExpect(() => {
       expect(wrapper.find('[class$="--error"]').exists()).toBe(true);
     });
@@ -128,8 +127,7 @@ describe('BnToggle', () => {
     const wrapper = mount(generateExampleForm(), { props: { validationSchema: { checkbox: isRequired } } });
     const input = wrapper.getComponent(BnToggle);
     expect(input.find('[class$="--error"]').exists()).toBe(false);
-    input.find('input').trigger('change');
-    await flushPromises();
+    wrapper.find('form').trigger('submit');
     await waitForExpect(() => {
       expect(input.find('[class$="--error"]').exists()).toBe(true);
     });

--- a/src/components/BnToggle/BnToggle.vue
+++ b/src/components/BnToggle/BnToggle.vue
@@ -2,14 +2,14 @@
 import { RuleExpression, useField } from 'vee-validate';
 import { useAttrs, ref, toRefs } from 'vue';
 
-type valueTypes = undefined | boolean | string | number | Record<string, unknown>;
+export type valueTypes = undefined | boolean | string | number | Record<string, unknown>;
 
 interface Props {
   modelValue?: valueTypes | valueTypes[],
   value: valueTypes,
   name: string,
   color?: string,
-  rules?: RuleExpression<unknown>,
+  rules?: RuleExpression<valueTypes | valueTypes[]>,
   disabled?: boolean,
 }
 
@@ -21,8 +21,6 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
 });
 
-const emit = defineEmits<{(e: 'update:modelValue', value: valueTypes | valueTypes[]): void}>();
-
 const { name, rules, value } = toRefs(props);
 
 const { handleChange, checked, meta, setTouched, errorMessage } = useField(name, rules, {
@@ -30,6 +28,7 @@ const { handleChange, checked, meta, setTouched, errorMessage } = useField(name,
   checkedValue: value,
   initialValue: props.modelValue,
   validateOnMount: true,
+  syncVModel: true,
 });
 
 function onChange(e: Event) {
@@ -43,11 +42,10 @@ function onChange(e: Event) {
     } else {
       newValue.splice(newValue.indexOf(props.value), 1);
     }
-    emit('update:modelValue', newValue);
+    handleChange(newValue);
   } else {
-    emit('update:modelValue', input.checked ? props.value : undefined);
+    handleChange(checked?.value ? value : undefined);
   }
-  handleChange(e);
 }
 
 const isFocusedVisible = ref(false);


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects
- Checkboxes weren't syncing external changes to their current value, which caused issues.

## Changes

- Update all form components to use vee-validate's syncVModel to handle v-model emits, to avoid having to handle that kind of thing in two places.
- Cleans up tests
- Fixes the type for vee-validate rules

