### PR TITLE
Classes prop

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -56,6 +56,30 @@ export default defineConfig({
               text: 'BnCheckbox',
               link: '/components/bn-checkbox',
             },
+            {
+              text: 'BnBtn',
+              link: '/components/bn-btn',
+            },
+            {
+              text: 'BnListbox',
+              link: '/components/bn-listbox',
+            },
+            {
+              text: 'BnModal',
+              link: '/components/bn-modal',
+            },
+            {
+              text: 'BnPagination',
+              link: '/components/bn-pagination',
+            },
+            {
+              text: 'BnTextarea',
+              link: '/components/bn-textarea',
+            },
+            {
+              text: 'BnToggle',
+              link: '/components/bn-toggle',
+            },
           ],
         },
       ],

--- a/docs/components/bn-btn.md
+++ b/docs/components/bn-btn.md
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import BnBtn from '../../src/components/BnBtn/BnBtn.vue';
+</script>
+
+# BnBtn
+
+BnBtn is a wrapper for `<button>` and `<a>` elements.
+
+## Basic Usage
+
+TODO
+
+## Input Attributes
+
+TODO
+
+## Vee-Validate
+
+TODO
+
+## Colors
+
+TODO
+
+## Slots
+
+TODO
+
+## Customization
+
+There are two ways to customize the appearance of the `BnBtn` component:
+
+### `classes` prop
+
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
+
+```html
+<bn-btn
+  class="bg-purple-600"
+  :loading="true"
+  :classes="{ loading: 'text-yellow-500' }"
+>
+  Name
+</bn-btn>
+```
+
+<code-preview>
+  <bn-btn
+    class="bg-purple-600"
+    :loading="true"
+    :classes="{ loading: 'text-yellow-500' }"
+  >
+    Name
+  </bn-btn>
+</code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `loading`: The loading indicator svg element
+
+### Theming
+
+You can change the default appearance or even add variants by editing the configuration of the TailwindCSS plugin.
+
+```javascript
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@headlessui/tailwindcss'),
+    banano.tailwindPlugin({
+      theme: {
+        BnBtn: {
+          '.bn-btn': {
+            '@apply bg-green-600': {},
+          }
+        }
+      }
+    }),
+  ],
+```
+
+You can find more information about customizing the library in [Theme Customization](../theme-customization.md).

--- a/docs/components/bn-checkbox.md
+++ b/docs/components/bn-checkbox.md
@@ -160,25 +160,30 @@ The underlying checkbox is wrapped by a `label` and the default slot gives it it
 </code-preview>
 
 ## Customization
+
 There are two ways to customize the appearance of the `BnCheckbox` component:
 
-### [TODO] Complex Style for Single Elements
+### `classes` prop
 
-If you want to modify the style of something else, you can use the `classes` prop, which will accept an object with each element that can be modified.
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
 
 ```html
-<template>
-  <bn-checkbox name="complex" :classes="{ label: 'bg-red-300 text-white' }">
-    Hello
-  </bn-checkbox>
-</template>
+<bn-checkbox :classes="{ input: 'rounded-full' }">
+  Name
+</bn-checkbox>
 ```
 
 <code-preview>
-  <bn-checkbox name="complex" :classes="{ label: 'bg-red-300 text-white' }">
-    Hello
+  <bn-checkbox :classes="{ input: 'rounded-full' }">
+    Name
   </bn-checkbox>
 </code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `input`: The `<input type="checkbox">` element itself
 
 ### Theming
 

--- a/docs/components/bn-file-input.md
+++ b/docs/components/bn-file-input.md
@@ -115,12 +115,12 @@ Due to the way Tailwind compiles classes, to avoid generating CSS for every sing
 
 This slot allows you to customize the entire `FileInput` appearance. It includes the following slot props:
 
-- `imagePreviewPath`: A function that takes a file as input and generates a URL to preview it.
-- `disabled`: A boolean indicating whether the input is disabled.
-- `openFileDialog`: A function that allows you to open the file upload window.
-- `removeFile`: A function that removes the provided file from the value. If the input allows a single file, it sets the value to `undefined`. If it allows multiple files, it removes the selected file from the list.
-- `addFile`: A function that adds a file. If the input allows a single file, it replaces the older file with the new one. If it allows multiple files, it adds the file to the list.
-- `value`: The input value. If it's a single file input, it returns a file object. If it's a multiple file input, it returns a file list.
+- `imagePreviewPath`: A function that takes a file as input and generates a URL to preview it
+- `disabled`: A boolean indicating whether the input is disabled
+- `openFileDialog`: A function that allows you to open the file upload window
+- `removeFile`: A function that removes the provided file from the value. If the input allows a single file, it sets the value to `undefined`. If it allows multiple files, it removes the selected file from the list
+- `addFile`: A function that adds a file. If the input allows a single file, it replaces the older file with the new one. If it allows multiple files, it adds the file to the list
+- `value`: The input value. If it's a single file input, it returns a file object. If it's a multiple file input, it returns a file list
 
 ```html
 <bn-file-input
@@ -296,9 +296,35 @@ Useful for hints or errors. Includes the following slot props:
 </code-preview>
 
 
-## [TODO] Customization
 
-TO DO.
+## Customization
+
+There are two ways to customize the appearance of the `BnFileInput` component:
+
+### `classes` prop
+
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
+
+```html
+<bn-file-input name="input" :classes="{ button: 'rounded-full' }" />
+```
+
+<code-preview>
+  <div class="grid col-span-1 gap-4">
+    <bn-file-input name="input" :classes="{ button: 'rounded-full' }" />
+  </div>
+</code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `wrapper`: The element surrounding everything but the `bottom` slot
+- `button`: The button that opens the file dialog
+- `avatar`: The `<button>` element when using the `avatar` variant. It contains the preview when file is selected
+- `label`: The element that contains either the placeholder or the file name and clear button
+- `placeholder`: The element that contains the placeholder text when no file is selected
+- `clear-button`: The button that clears the selected file(s)
 
 ### Theming
 

--- a/docs/components/bn-input.md
+++ b/docs/components/bn-input.md
@@ -276,27 +276,12 @@ Useful for hints or errors. Includes the following slot props:
 </code-preview>
 
 ## Customization
-There are three ways to customize the appearance of the `BnInput` component:
 
-### [TODO] Input Classes
+There are two ways to customize the appearance of the `BnInput` component:
 
-If you only need to change the appearance of the `input` element you can use the prop `input-classes`:
+### `classes` prop
 
-```html
-<bn-input name="name" input-classes="rounded-none" />
-<bn-input name="pink" input-classes="bg-pink-300" />
-```
-
-<code-preview>
-  <div class="grid col-span-1 gap-4">
-    <bn-input name="name" input-classes="rounded-none" />
-    <bn-input name="pink" input-classes="bg-pink-100" />
-  </div>
-</code-preview>
-
-### [TODO] Complex Style for Single Elements
-
-If you want to modify the style of something else, you can use the `classes` prop, which will accept an object with each element that can be modified.
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
 
 ```html
 <template>
@@ -311,6 +296,13 @@ If you want to modify the style of something else, you can use the `classes` pro
     <template #prefix>Hello</template>
   </bn-input>
 </code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+- `input`: The `<input>` element
+- `prefix`: The element surrounding the `prefix` slot
+- `suffix`: The element surrounding the `suffix` slot
 
 ### Theming
 

--- a/docs/components/bn-listbox.md
+++ b/docs/components/bn-listbox.md
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import BnListbox from '../../src/components/BnListbox/BnListbox.vue';
+
+const selected = ref(undefined);
+</script>
+
+# BnListbox
+
+BnListbox is a wrapper for a `<select>` element. It is built on top of [HeadlessUI's Listbox](https://headlessui.dev/vue/listbox) component.
+
+## Basic Usage
+
+TODO
+
+## Input Attributes
+
+TODO
+
+## Vee-Validate
+
+TODO
+
+## Colors
+
+TODO
+
+## Slots
+
+TODO
+
+## Customization
+
+There are two ways to customize the appearance of the `BnListbox` component:
+
+### `classes` prop
+
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
+
+```html
+<bn-listbox
+  v-model="selected"
+  :classes="{ button: 'border-4 border-purple-500' }"
+  :options="['Option 1', 'Option 2', 'Option 3']"
+>
+  Name
+</bn-listbox>
+```
+
+<code-preview>
+  <bn-listbox
+    v-model="selected"
+    :classes="{ button: 'border-8 rounded-full' }"
+    :options="['Option 1', 'Option 2', 'Option 3']"
+  >
+    Name
+  </bn-listbox>
+</code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `button`: The `ListboxButton` element
+- `tag`: Every individual tag when using the `multiple` prop
+- `options`: The `ListboxOptions` element
+- `option`: Every individual `ListboxOption` element
+
+### Theming
+
+You can change the default appearance or even add variants by editing the configuration of the TailwindCSS plugin.
+
+```javascript
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@headlessui/tailwindcss'),
+    banano.tailwindPlugin({
+      theme: {
+        BnListbox: {
+          '.bn-listbox': {
+            '@apply bg-green-600': {},
+          }
+        }
+      }
+    }),
+  ],
+```
+
+You can find more information about customizing the library in [Theme Customization](../theme-customization.md).

--- a/docs/components/bn-modal.md
+++ b/docs/components/bn-modal.md
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import BnModal from '../../src/components/BnModal/BnModal.vue';
+import BnBtn from '../../src/components/BnBtn/BnBtn.vue';
+
+const open = ref(false);
+</script>
+
+# BnModal
+
+BnModal is a wrapper for [HeadlessUI's Dialog](https://headlessui.dev/vue/dialog) component.
+
+## Basic Usage
+
+TODO
+
+## Input Attributes
+
+TODO
+
+## Vee-Validate
+
+TODO
+
+## Colors
+
+TODO
+
+## Slots
+
+TODO
+
+## Customization
+
+There are two ways to customize the appearance of the `BnModal` component:
+
+### `classes` prop
+
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
+
+```html
+<bn-btn @click="state.open = true">
+  Open modal
+</bn-btn>
+<bn-modal
+  title="This is the header"
+  description="This is the body"
+  :open="state.open"
+  :classes="{ overlay: 'bg-yellow-500/30' }"
+  @close="state.open = false"
+>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent euismod interdum orci eget ornare.</p>
+</bn-modal>
+```
+
+<code-preview>
+  <bn-btn @click="open = true">
+    Open modal
+  </bn-btn>
+  <bn-modal
+    title="This is the header"
+    description="This is the body"
+    :open="open"
+    :classes="{ overlay: 'bg-yellow-500/30' }"
+    @close="open = false"
+  >
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent euismod interdum orci eget ornare.</p>
+  </bn-modal>
+</code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `overlay`: The overlay/backdrop rendered behind the modal
+- `content`: The modal itself, a `DialogPanel` element
+- `close-button`: The close button
+- `header`: The `DialogTitle` element containing the title prop
+- `body`: The `DialogDescription` element containing the description prop
+
+### Theming
+
+You can change the default appearance or even add variants by editing the configuration of the TailwindCSS plugin.
+
+```javascript
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@headlessui/tailwindcss'),
+    banano.tailwindPlugin({
+      theme: {
+        BnModal: {
+          '.bn-modal': {
+            '@apply bg-green-600': {},
+          }
+        }
+      }
+    }),
+  ],
+```
+
+You can find more information about customizing the library in [Theme Customization](../theme-customization.md).

--- a/docs/components/bn-pagination.md
+++ b/docs/components/bn-pagination.md
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import BnPagination from '../../src/components/BnPagination/BnPagination.vue';
+
+const currentPage = ref(21);
+</script>
+
+# BnPagination
+
+BnPagination is a wrapper for [HeadlessUI's Dialog](https://headlessui.dev/vue/dialog) component.
+
+## Basic Usage
+
+TODO
+
+## Input Attributes
+
+TODO
+
+## Vee-Validate
+
+TODO
+
+## Colors
+
+TODO
+
+## Slots
+
+TODO
+
+## Customization
+
+There are two ways to customize the appearance of the `BnPagination` component:
+
+### `classes` prop
+
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
+
+```html
+<bn-pagination
+  :total-pages="50"
+  :current-page="currentPage"
+  :classes="{ list: 'justify-between flex-1' }"
+  @page-changed="currentPage = $event"
+/>
+```
+
+<code-preview>
+  <bn-pagination
+    :total-pages="50"
+    :current-page="currentPage"
+    :classes="{ list: 'justify-between flex-1' }"
+    @page-changed="currentPage = $event"
+  />
+</code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `list`: The `<ul>` element that wraps the pagination buttons.
+
+### Theming
+
+You can change the default appearance or even add variants by editing the configuration of the TailwindCSS plugin.
+
+```javascript
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@headlessui/tailwindcss'),
+    banano.tailwindPlugin({
+      theme: {
+        BnPagination: {
+          '.bn-pagination': {
+            '@apply text-green-600': {},
+          }
+        }
+      }
+    }),
+  ],
+```
+
+You can find more information about customizing the library in [Theme Customization](../theme-customization.md).

--- a/docs/components/bn-textarea.md
+++ b/docs/components/bn-textarea.md
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import BnTextarea from '../../src/components/BnTextarea/BnTextarea.vue';
+
+const value = ref('');
+</script>
+
+# BnTextarea
+
+BnTextarea is a wrapper for a `<textarea>` element.
+
+## Basic Usage
+
+TODO
+
+## Input Attributes
+
+TODO
+
+## Vee-Validate
+
+TODO
+
+## Colors
+
+TODO
+
+## Slots
+
+TODO
+
+## Customization
+
+There are two ways to customize the appearance of the `BnTextarea` component:
+
+### `classes` prop
+
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
+
+```html
+<bn-textarea
+  v-model="value"
+  :classes="{ textarea: 'border-4 rounded-none' }"
+/>
+```
+
+<code-preview>
+  <bn-textarea
+    v-model="value"
+    :classes="{ textarea: 'border-4 rounded-none' }"
+  />
+</code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `textarea`: The `<textarea>` element itself
+
+### Theming
+
+You can change the default appearance or even add variants by editing the configuration of the TailwindCSS plugin.
+
+```javascript
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@headlessui/tailwindcss'),
+    banano.tailwindPlugin({
+      theme: {
+        BnTextarea: {
+          '.bn-textarea': {
+            '@apply text-green-600': {},
+          }
+        }
+      }
+    }),
+  ],
+```
+
+You can find more information about customizing the library in [Theme Customization](../theme-customization.md).

--- a/docs/components/bn-toggle.md
+++ b/docs/components/bn-toggle.md
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import BnToggle from '../../src/components/BnToggle/BnToggle.vue';
+
+const selected = ref(false);
+</script>
+
+# BnToggle
+
+BnToggle is a wrapper for a `<input type="checkbox">` element, but with the appearance of a toggle switch.
+
+## Basic Usage
+
+TODO
+
+## Input Attributes
+
+TODO
+
+## Vee-Validate
+
+TODO
+
+## Colors
+
+TODO
+
+## Slots
+
+TODO
+
+## Customization
+
+There are two ways to customize the appearance of the `BnToggle` component:
+
+### `classes` prop
+
+Every component has a `classes` prop that will accept an object where each key corresponds to an internal element of the component. The value of each key will be the classes that will be applied to that element. For the values, you can use strings, objects or arrays, the same way it works with [Vue's class binding](https://vuejs.org/guide/essentials/class-and-style.html).
+
+```html
+<bn-toggle
+  name="toggle"
+  v-model="selected"
+  :value="true"
+  :classes="{
+    ball: ['rounded-none', { 'bg-yellow-500': selected }],
+    track: ['rounded-none', { 'bg-purple-200': selected }]
+  }"
+>
+  This is a toggle
+</bn-toggle>
+```
+
+<code-preview>
+  <bn-toggle
+    name="toggle"
+    v-model="selected"
+    :value="true"
+    :classes="{
+      ball: ['rounded-none', { 'bg-yellow-500': selected }],
+      track: ['h-3', { 'bg-purple-200': selected }]
+    }"
+  >
+    This is a toggle
+  </bn-toggle>
+</code-preview>
+
+Default styles will still be applied, but the classes you provide will take precedence, so you can use this to override any existing style.
+
+The available keys for this component are:
+
+- `ball`: The ball of the toggle
+- `track`: The track of the toggle
+
+### Theming
+
+You can change the default appearance or even add variants by editing the configuration of the TailwindCSS plugin.
+
+```javascript
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@headlessui/tailwindcss'),
+    banano.tailwindPlugin({
+      theme: {
+        BnToggle: {
+          '.bn-toggle__track--focus-visible': {
+            '@apply ring-green-600': {},
+          }
+        }
+      }
+    }),
+  ],
+```
+
+You can find more information about customizing the library in [Theme Customization](../theme-customization.md).

--- a/docs/theme-customization.md
+++ b/docs/theme-customization.md
@@ -1,4 +1,4 @@
 # Theme Customization
 
-* [Classes and Components](#classes-and-components)
-* [Colors](#colors)
+* [Classes and Components](./classes-and-components)
+* [Colors](./colors)

--- a/src/components/BnBtn/BnBtn.story.vue
+++ b/src/components/BnBtn/BnBtn.story.vue
@@ -154,6 +154,18 @@ defineExpose({
         </BnBtn>
       </template>
     </Variant>
+    <Variant
+      title="With classes customization"
+    >
+      <template #default>
+        <BnBtn
+          :classes="{ loading: 'text-yellow-500' }"
+          :loading="true"
+        >
+          Loading ...
+        </BnBtn>
+      </template>
+    </Variant>
   </Story>
 </template>
 

--- a/src/components/BnBtn/BnBtn.story.vue
+++ b/src/components/BnBtn/BnBtn.story.vue
@@ -49,7 +49,7 @@ defineExpose({
 
 <template>
   <Story
-    title="Btn"
+    title="BnBtn"
     :layout="{ type: 'grid', width: '300px' }"
   >
     <Variant title="default">
@@ -76,7 +76,7 @@ defineExpose({
     <Variant
       v-for="(props, key) of sizeVariants"
       :key="key"
-      :title="'Btn ' + props.size"
+      :title="'BnBtn ' + props.size"
       class="bg-white"
     >
       <BnBtn v-bind="props">
@@ -86,7 +86,7 @@ defineExpose({
     <Variant
       v-for="(props, key) of shapeVariants"
       :key="key"
-      :title="'Btn ' + props.shape"
+      :title="'BnBtn ' + props.shape"
     >
       <BnBtn v-bind="props">
         {{ props.text ? props.text : state.text }}
@@ -95,7 +95,7 @@ defineExpose({
     <Variant
       v-for="(props, key) of variantVariants"
       :key="key"
-      :title="'Btn ' + props.variant"
+      :title="'BnBtn ' + props.variant"
     >
       <BnBtn v-bind="props">
         {{ state.text }}
@@ -104,7 +104,7 @@ defineExpose({
     <Variant
       v-for="(props, key) of colorVariants"
       :key="key"
-      :title="'Btn ' + Object.keys(props).join(' ')"
+      :title="'BnBtn ' + Object.keys(props).join(' ')"
     >
       <BnBtn v-bind="props">
         {{ state.text }}
@@ -113,7 +113,7 @@ defineExpose({
     <Variant
       v-for="(props, key) of sizeVariants"
       :key="key"
-      :title="`Btn with icons ${props.size}`"
+      :title="`BnBtn with icons ${props.size}`"
     >
       <template #default>
         <BnBtn v-bind="props">

--- a/src/components/BnBtn/BnBtn.vue
+++ b/src/components/BnBtn/BnBtn.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  loading?: ComponentClassType
+}
 
 interface Props {
   as?: string
@@ -9,6 +14,7 @@ interface Props {
   color?: string
   loading?: boolean
   loadingReplacesContent?: boolean
+  classes?: ClassesProp
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -19,6 +25,7 @@ const props = withDefaults(defineProps<Props>(), {
   color: 'banano-base',
   loading: false,
   loadingReplacesContent: false,
+  classes: () => ({}),
 });
 
 const attrs = useAttrs();
@@ -56,7 +63,10 @@ const tag = computed(() => {
         <svg
           v-if="loading"
           class="bn-btn__loading"
-          :class="`bn-btn__loading--sizes-${props.size}`"
+          :class="[
+            `bn-btn__loading--sizes-${props.size}`,
+            props.classes.loading
+          ]"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -88,7 +98,10 @@ const tag = computed(() => {
     <template v-else>
       <svg
         class="bn-btn__loading bn-btn__loading--no-content"
-        :class="`bn-btn__loading--sizes-${props.size}`"
+        :class="[
+          `bn-btn__loading--sizes-${props.size}`,
+          props.classes.loading
+        ]"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/src/components/BnCheckbox/BnCheckbox.story.vue
+++ b/src/components/BnCheckbox/BnCheckbox.story.vue
@@ -121,6 +121,21 @@ function isRequired(val: string) {
         </BnCheckbox>
       </template>
     </Variant>
+    <Variant title="With classes customization">
+      <template #default>
+        <BnCheckbox
+          v-model="state.single"
+          name="custom-classes"
+          value="Checked"
+          color="lime"
+          :classes="{
+            input: 'rounded-full',
+          }"
+        >
+          This is a checkbox
+        </BnCheckbox>
+      </template>
+    </Variant>
   </Story>
 </template>
 

--- a/src/components/BnCheckbox/BnCheckbox.vue
+++ b/src/components/BnCheckbox/BnCheckbox.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
 import { toRefs, useAttrs, computed } from 'vue';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  input?: ComponentClassType,
+}
 
 export type ValueType = undefined | boolean | string | number | Record<string, unknown>;
 
@@ -12,6 +17,7 @@ interface Props {
   rules?: RuleExpression<ValueType | ValueType[]>,
   disabled?: boolean,
   uncheckedValue?: ValueType,
+  classes?: ClassesProp,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -21,6 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
   rules: undefined,
   disabled: false,
   uncheckedValue: undefined,
+  classes: () => ({}),
 });
 
 const { name, uncheckedValue, rules, value } = toRefs(props);
@@ -71,7 +78,8 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
       class="bn-checkbox__input"
       :class="[
         `bn-checkbox__input--${props.color}`,
-        {'bn-checkbox__input--error': hasError}
+        {'bn-checkbox__input--error': hasError},
+        props.classes.input,
       ]"
       v-bind="attrsWithoutClass"
       :disabled="props.disabled"

--- a/src/components/BnFileInput/BnFileInput.story.vue
+++ b/src/components/BnFileInput/BnFileInput.story.vue
@@ -268,5 +268,32 @@ function isRequired(val: File[] | File | undefined) {
         </BnFileInput>
       </template>
     </Variant>
+    <Variant title="With classes customization (default)">
+      <template #default>
+        <BnFileInput
+          v-model="state.single"
+          name="custom-classes-default"
+          :classes="{
+            wrapper: 'border-yellow-300 bg-yellow-50/50',
+            button: 'rounded-full',
+            label: 'text-purple-500',
+            placeholder: 'text-purple-300',
+            'clear-button': 'text-red-500',
+          }"
+        />
+      </template>
+    </Variant>
+    <Variant title="With classes customization (avatar)">
+      <template #default>
+        <BnFileInput
+          v-model="state.avatar"
+          name="custom-classes-avatar"
+          variant="avatar"
+          :classes="{
+            avatar: 'rounded-3xl border-yellow-300 bg-yellow-50/50 text-yellow-500 overflow-hidden',
+          }"
+        />
+      </template>
+    </Variant>
   </Story>
 </template>

--- a/src/components/BnFileInput/BnFileInput.vue
+++ b/src/components/BnFileInput/BnFileInput.vue
@@ -2,6 +2,16 @@
 import { RuleExpression, useField } from 'vee-validate';
 import { computed, ref, toRef } from 'vue';
 import BnBtn from '../BnBtn/BnBtn.vue';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  wrapper?: ComponentClassType,
+  button?: ComponentClassType,
+  avatar?: ComponentClassType,
+  label?: ComponentClassType,
+  placeholder?: ComponentClassType,
+  'clear-button'?: ComponentClassType,
+}
 
 export type FileType = File[] | File | undefined;
 
@@ -16,6 +26,7 @@ interface Props {
   placeholder?: string
   variant?: 'default' | 'avatar'
   avatarShape?: string
+  classes?: ClassesProp
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -28,6 +39,7 @@ const props = withDefaults(defineProps<Props>(), {
   buttonText: 'Browse',
   variant: 'default',
   avatarShape: 'default',
+  classes: () => ({}),
 });
 
 const fileInputRef = ref<HTMLInputElement>();
@@ -151,7 +163,8 @@ function removeFile(file: File) {
           'bn-file-input__wrapper--disabled': props.disabled,
           'bn-file-input__wrapper--custom': $slots['default'],
           'bn-file-input__wrapper--error': meta.touched && !meta.valid,
-        }
+        },
+        props.classes.wrapper,
       ]"
     >
       <input
@@ -178,6 +191,7 @@ function removeFile(file: File) {
             size="xs"
             type="button"
             class="bn-file-input__button"
+            :class="props.classes.button"
             variant="outline"
             :disabled="props.disabled"
             @click="openFileDialog"
@@ -189,7 +203,10 @@ function removeFile(file: File) {
           <button
             type="button"
             class="bn-file-input__avatar"
-            :class="`bn-file-input__avatar--${props.avatarShape}`"
+            :class="[
+              `bn-file-input__avatar--${props.avatarShape}`,
+              props.classes.avatar,
+            ]"
             :disabled="props.disabled"
             @click="openFileDialog"
           >
@@ -206,6 +223,7 @@ function removeFile(file: File) {
         <div
           v-if="variant !== 'avatar'"
           class="bn-file-input__label"
+          :class="props.classes.label"
         >
           <div
             v-if="fileNames"
@@ -217,6 +235,7 @@ function removeFile(file: File) {
             <button
               type="button"
               class="bn-file-input__clear-button"
+              :class="props.classes['clear-button']"
               @click="inputValue = undefined"
             >
               <svg
@@ -233,6 +252,7 @@ function removeFile(file: File) {
           <span
             v-else
             class="bn-file-input__placeholder"
+            :class="props.classes.placeholder"
           >
             {{ props.placeholder }}
           </span>

--- a/src/components/BnInput/BnInput.story.vue
+++ b/src/components/BnInput/BnInput.story.vue
@@ -181,6 +181,26 @@ function isRequired(val: string) {
         </BnInput>
       </template>
     </Variant>
+    <Variant title="With classes customization">
+      <template #default>
+        <BnInput
+          v-model="state.value"
+          name="custom-classes"
+          :classes="{
+            input: 'border-2 border-orange-500',
+            prefix: 'text-yellow-500',
+            suffix: 'text-purple-500',
+          }"
+        >
+          <template #prefix>
+            +56 9
+          </template>
+          <template #suffix>
+            .com
+          </template>
+        </BnInput>
+      </template>
+    </Variant>
   </Story>
 </template>
 

--- a/src/components/BnInput/BnInput.vue
+++ b/src/components/BnInput/BnInput.vue
@@ -1,18 +1,27 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
 import { toRefs, useAttrs } from 'vue';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  input?: ComponentClassType,
+  prefix?: ComponentClassType,
+  suffix?: ComponentClassType,
+}
 
 interface Props {
   modelValue?: string | number
   name: string
   color?: string
   rules?: RuleExpression<string | number>,
+  classes?: ClassesProp,
 }
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: undefined,
   color: 'banano-base',
   rules: undefined,
+  classes: () => ({}),
 });
 
 const { name, rules } = toRefs(props);
@@ -50,6 +59,7 @@ export default {
       <div
         v-if="$slots['prefix']"
         class="bn-input__prefix"
+        :class="props.classes.prefix"
       >
         <slot name="prefix" />
       </div>
@@ -74,7 +84,8 @@ export default {
               'bn-input__input--prefix': $slots['prefix'],
               'bn-input__input--suffix': $slots['suffix'],
               'bn-input__input--error': !meta.valid && meta.touched,
-            }
+            },
+            props.classes.input,
           ]"
           @input="handleChange"
           @blur="handleBlur"
@@ -89,6 +100,7 @@ export default {
       <div
         v-if="$slots['suffix']"
         class="bn-input__suffix"
+        :class="props.classes.suffix"
       >
         <slot name="suffix" />
       </div>

--- a/src/components/BnListbox/BnListbox.story.vue
+++ b/src/components/BnListbox/BnListbox.story.vue
@@ -258,6 +258,22 @@ function isRequired(val: string) {
         </BnListbox>
       </template>
     </Variant>
+    <Variant title="With classes customization">
+      <template #default>
+        <BnListbox
+          v-model="state.multiple"
+          name="multiple"
+          multiple
+          :options="selectOptions"
+          :classes="{
+            button: 'bg-yellow-100',
+            tag: 'bg-purple-50 border border-purple-200',
+            options: 'border-purple-900',
+            option: 'ui-active:bg-purple-200 ui-selected:bg-purple-300',
+          }"
+        />
+      </template>
+    </Variant>
   </Story>
 </template>
 

--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -10,6 +10,14 @@ import {
 } from '@headlessui/vue';
 import { computePosition, flip, offset } from '@floating-ui/dom';
 import isEmpty from 'lodash/isEmpty';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  button?: ComponentClassType,
+  tag?: ComponentClassType,
+  options?: ComponentClassType,
+  option?: ComponentClassType,
+}
 
 type InputValue = number | string | Record<string, unknown> | undefined;
 
@@ -26,6 +34,7 @@ interface Props {
   optionLabel?: string
   keepObjectValue?: boolean
   placeholder?: string
+  classes?: ClassesProp,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -38,6 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
   optionLabel: undefined,
   keepObjectValue: false,
   placeholder: undefined,
+  classes: () => ({}),
 });
 
 const useObjectOptions = !!props.trackBy && !!props.optionLabel;
@@ -185,7 +195,8 @@ const formValue = computed({
           {
             'bn-listbox__button--error': !meta.valid && meta.touched,
             'bn-listbox__button--disabled': props.disabled
-          }
+          },
+          props.classes.button
         ]"
         @blur="setTouched(true)"
       >
@@ -209,7 +220,9 @@ const formValue = computed({
             >
               <span
                 class="bn-listbox__tag"
-                :class="`bn-listbox__tag--${props.color}`"
+                :class="[
+                  `bn-listbox__tag--${props.color}`, props.classes.tag
+                ]"
               >
                 {{ isObjectValue(option) ? option[props.optionLabel as string] : option }}
               </span>
@@ -241,7 +254,10 @@ const formValue = computed({
         <ListboxOptions
           ref="listboxOptionsRef"
           class="bn-listbox-options"
-          :class="[`bn-listbox-options--${props.color}`]"
+          :class="[
+            `bn-listbox-options--${props.color}`,
+            props.classes.options
+          ]"
           :style="`width: ${listboxButtonWidth}px`"
         >
           <ListboxOption
@@ -250,7 +266,10 @@ const formValue = computed({
             :key="isObjectValue(option) ? (option[props.trackBy as string] as string) : option"
             :value="option"
             class="bn-listbox-options__option"
-            :class="`bn-listbox-options__option--${props.color}`"
+            :class="[
+              `bn-listbox-options__option--${props.color}`,
+              props.classes.option
+            ]"
           >
             <slot
               name="option-template"

--- a/src/components/BnModal/BnModal.story.vue
+++ b/src/components/BnModal/BnModal.story.vue
@@ -59,5 +59,34 @@ const state = reactive({
         </BnModal>
       </template>
     </Variant>
+    <Variant
+      title="With classes customization"
+      auto-props-disabled
+    >
+      <template #default>
+        <BnBtn @click="state.open = true">
+          Open modal
+        </BnBtn>
+        <BnModal
+          title="This is the header"
+          description="This is the body"
+          :open="state.open"
+          :classes="{
+            overlay: 'bg-yellow-500/30',
+            content: 'border-2 border-yellow-500',
+            'close-button': 'text-red-500',
+            header: 'bg-yellow-200 text-purple-900',
+            body: 'bg-yellow-50 text-black',
+          }"
+          @close="state.open = false"
+        >
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent euismod interdum orci eget ornare.</p>
+          <p>
+            Donec vel congue urna, sed euismod ante. Curabitur tempus viverra diam at egestas.
+            Nunc auctor ipsum sit amet turpis sodales, id porta enim dignissim. Maecenas volutpat erat orci.
+          </p>
+        </BnModal>
+      </template>
+    </Variant>
   </Story>
 </template>

--- a/src/components/BnModal/BnModal.vue
+++ b/src/components/BnModal/BnModal.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
 import { Dialog, DialogPanel, DialogTitle, DialogDescription } from '@headlessui/vue';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  overlay?: ComponentClassType,
+  content?: ComponentClassType,
+  'close-button'?: ComponentClassType,
+  header?: ComponentClassType,
+  body?: ComponentClassType,
+}
 
 interface Props {
   open?: boolean,
@@ -8,6 +17,7 @@ interface Props {
   fullScreenOnMobile?: boolean,
   showCloseButton?: boolean,
   closeOnOverlayClick?: boolean,
+  classes?: ClassesProp,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -17,6 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
   fullScreenOnMobile: false,
   showCloseButton: true,
   closeOnOverlayClick: true,
+  classes: () => ({}),
 });
 
 const emit = defineEmits<{
@@ -31,17 +42,24 @@ const emit = defineEmits<{
     :open="open"
     @close="props.closeOnOverlayClick && emit('close', $event)"
   >
-    <div class="bn-modal__overlay" />
+    <div
+      class="bn-modal__overlay"
+      :class="props.classes.overlay"
+    />
     <div class="bn-modal__wrapper">
       <DialogPanel
         class="bn-modal__content"
-        :class="{
-          'bn-modal__content--full-screen-on-mobile': fullScreenOnMobile,
-        }"
+        :class="[
+          {
+            'bn-modal__content--full-screen-on-mobile': fullScreenOnMobile,
+          },
+          props.classes.content,
+        ]"
       >
         <button
           v-if="showCloseButton"
           class="bn-modal__close-button"
+          :class="props.classes['close-button']"
           @click="emit('close', false)"
         >
           <svg
@@ -57,10 +75,14 @@ const emit = defineEmits<{
         <DialogTitle
           v-if="props.title"
           class="bn-modal__header"
+          :class="props.classes.header"
         >
           {{ props.title }}
         </DialogTitle>
-        <div class="bn-modal__body">
+        <div
+          class="bn-modal__body"
+          :class="props.classes.body"
+        >
           <DialogDescription
             v-if="props.description"
             class="bn-modal__description"

--- a/src/components/BnPagination/BnPagination.story.vue
+++ b/src/components/BnPagination/BnPagination.story.vue
@@ -20,6 +20,18 @@ const state = reactive({
         />
       </template>
     </Variant>
+    <Variant title="With classes customization">
+      <template #default>
+        <BnPagination
+          :total-pages="pages"
+          :current-page="state.currentPage"
+          :classes="{
+            list: 'justify-between flex-1',
+          }"
+          @page-changed="state.currentPage = $event"
+        />
+      </template>
+    </Variant>
   </Story>
 </template>
 

--- a/src/components/BnPagination/BnPagination.vue
+++ b/src/components/BnPagination/BnPagination.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import BnBtn from '../BnBtn/BnBtn.vue';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  list?: ComponentClassType,
+}
 
 interface Props {
   as?: string,
@@ -9,6 +14,7 @@ interface Props {
   currentPage: number,
   delta?: number,
   color?: string,
+  classes?: ClassesProp,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -16,6 +22,7 @@ const props = withDefaults(defineProps<Props>(), {
   templateUrl: undefined,
   delta: 1,
   color: undefined,
+  classes: () => ({}),
 });
 
 const emit = defineEmits<{
@@ -74,7 +81,10 @@ function parseUrl(urlTemplate: string, page: number) {
     :is="props.as"
     class="bn-pagination"
   >
-    <ul class="bn-pagination__list">
+    <ul
+      class="bn-pagination__list"
+      :class="props.classes.list"
+    >
       <li v-if="pageItems.prev">
         <BnBtn
           :color="props.color"

--- a/src/components/BnTextarea/BnTextarea.story.vue
+++ b/src/components/BnTextarea/BnTextarea.story.vue
@@ -100,5 +100,19 @@ function isRequired(val: string) {
         </BnTextarea>
       </template>
     </Variant>
+    <Variant title="With classes customization">
+      <template #default>
+        <BnTextarea
+          v-model="state.value"
+          name="default"
+          :classes="{
+            textarea: [
+              'border-4 border-purple-500',
+              { 'border-green-500': !!state.value }
+            ],
+          }"
+        />
+      </template>
+    </Variant>
   </Story>
 </template>

--- a/src/components/BnTextarea/BnTextarea.vue
+++ b/src/components/BnTextarea/BnTextarea.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
 import { toRefs, useAttrs } from 'vue';
+import { type ComponentClassType } from '../../types/class';
+
+interface ClassesProp {
+  textarea?: ComponentClassType,
+}
 
 interface Props {
   modelValue?: string | number
   name: string
   color?: string
   rules?: RuleExpression<string | number>,
+  classes?: ClassesProp,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -14,6 +20,7 @@ const props = withDefaults(defineProps<Props>(), {
   modelValue: undefined,
   color: 'banano-base',
   rules: undefined,
+  classes: () => ({}),
 });
 
 const { name, rules } = toRefs(props);
@@ -49,7 +56,8 @@ defineOptions({
       class="bn-textarea__textarea"
       :class="[
         `bn-textarea__textarea--${props.color}`,
-        { 'bn-textarea__textarea--error': !meta.valid && meta.touched }
+        { 'bn-textarea__textarea--error': !meta.valid && meta.touched },
+        props.classes.textarea,
       ]"
       :value="(inputValue as string)"
       :name="name"

--- a/src/components/BnToggle/BnToggle.story.vue
+++ b/src/components/BnToggle/BnToggle.story.vue
@@ -26,6 +26,7 @@ const state = reactive({
   object: [],
   disabled: undefined,
   validateCustom: undefined,
+  customClasses: false,
 });
 
 /* eslint-disable max-len, vue/max-len */
@@ -162,6 +163,21 @@ function isRequired(val: string) {
               </svg>
             </div>
           </template>
+        </BnToggle>
+      </template>
+    </Variant>
+    <Variant title="With classes customization">
+      <template #default>
+        <BnToggle
+          v-model="state.customClasses"
+          name="custom-classes"
+          :value="true"
+          :classes="{
+            ball: { 'bg-yellow-500': state.customClasses },
+            track: { 'bg-purple-200': state.customClasses }
+          }"
+        >
+          This is a toggle
         </BnToggle>
       </template>
     </Variant>

--- a/src/components/BnToggle/BnToggle.vue
+++ b/src/components/BnToggle/BnToggle.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
 import { useAttrs, ref, toRefs } from 'vue';
+import { type ComponentClassType } from '../../types/class';
 
+interface ClassesProp {
+  ball?: ComponentClassType,
+  track?: ComponentClassType,
+}
 export type valueTypes = undefined | boolean | string | number | Record<string, unknown>;
 
 interface Props {
@@ -11,6 +16,7 @@ interface Props {
   color?: string,
   rules?: RuleExpression<valueTypes | valueTypes[]>,
   disabled?: boolean,
+  classes?: ClassesProp,
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -19,6 +25,7 @@ const props = withDefaults(defineProps<Props>(), {
   color: 'banano-base',
   rules: undefined,
   disabled: false,
+  classes: () => ({}),
 });
 
 const { name, rules, value } = toRefs(props);
@@ -87,14 +94,20 @@ const attrsWithoutClass = Object.fromEntries(Object.entries(attrs).filter(([key]
         >
         <div
           class="bn-toggle__track"
-          :class="{
-            [`bn-toggle__track--checked bn-toggle__track--checked-${props.color}`]: checked,
-            [`bn-toggle__track--focus-visible bn-toggle__track--focus-visible-${props.color}`]: isFocusedVisible,
-          }"
+          :class="[
+            {
+              [`bn-toggle__track--checked bn-toggle__track--checked-${props.color}`]: checked,
+              [`bn-toggle__track--focus-visible bn-toggle__track--focus-visible-${props.color}`]: isFocusedVisible,
+            },
+            props.classes.track,
+          ]"
         />
         <div
           class="bn-toggle__ball"
-          :class="{ 'bn-toggle__ball--checked': checked }"
+          :class="[
+            { 'bn-toggle__ball--checked': checked },
+            props.classes.ball,
+          ]"
         />
       </div>
       <slot />

--- a/src/types/class.ts
+++ b/src/types/class.ts
@@ -1,0 +1,2 @@
+type StringOrBooleanObject = string | Record<string, boolean>;
+export type ComponentClassType = StringOrBooleanObject | StringOrBooleanObject[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,11 +159,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.16.4":
-  version "7.18.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.5.tgz#337062363436a893a2d22faa60be5bb37091c83c"
-  integrity sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==
-
 "@babel/parser@^7.20.15", "@babel/parser@^7.21.3":
   version "7.22.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.7.tgz#df8cf085ce92ddbdbf668a7f186ce848c9036cae"


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects
- Currently, styling of components is done using classes that follow the BEM standard that can then be modified in the Tailwind config of a project

## Changes

This PR adds a new way to style individual components: through a `classes` prop that every component in this library has. It takes an object as value that has keys for each relevant element inside of the component, so you can apply new classes to those elements. For each component, the following were added:

- The `classes` prop
- Example(s) in the story that use every key available in the `classes` prop
- A description of how the prop works in the components documentation. This includes an explanation that is the same for every component, a small example and descriptions of every key available. I added documentations with this for any component that was missing it's file

Also, some extras:
- In `BnBtn`'s story, the story name was changed to match the recent component name change
- Added a change that was appearing when running `yarn`
- Export a type for values of the `classes` prop, which accepts the same types as Vue's class binding
- Fixed some broken links in the docs