### PR TITLE
Chore/npm publish

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,14 +19,16 @@ yarn add banano vee-validate
 # If using the tailwind plugin
 yarn add @headlessui/tailwindcss @tailwindcss/forms
 ```
-
+Then, in any component, you can import components from Banano as shown below:
 ```typescript
-import { createApp } from 'vue';
-import banano from 'banano';
+<script>
+import { BnInput } from 'banano';
+</script>
+<template>
+  <bn-input name="name">
+  </bn-input>
+</template>
 
-const app = createApp({...});
-app.use(banano);
-app.mount();
 ```
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "banano",
-  "private": true,
+  "private": false,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects. Since it is a library, we need to publish it on npm.

## Changes

* Updated package.json configuration to set it as public, allowing the library to be published.
* Documented the correct way to import Banano into projects.
