### PR TITLE
fix(bn-file-input): prevent dialog open when clicking clear btn

### DIFF
--- a/src/components/BnFileInput/BnFileInput.vue
+++ b/src/components/BnFileInput/BnFileInput.vue
@@ -236,7 +236,7 @@ function removeFile(file: File) {
               type="button"
               class="bn-file-input__clear-button"
               :class="props.classes['clear-button']"
-              @click="inputValue = undefined"
+              @click.prevent="inputValue = undefined"
             >
               <svg
                 class="bn-file-input__clear-button-icon"


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects

## Changes

This PR fixes an issue that was causing the file dialog to open when clicking the clear button. This was caused because the whole component is wrapped in a label, so clicking anywhere in it would trigger the dialog. A `.prevent` was enough to avoid it.

**Before**

https://github.com/platanus/banano/assets/12057523/2ba7c1bf-89dd-48cf-ae3c-d0544e2a2e90

**Now**

https://github.com/platanus/banano/assets/12057523/d03126d0-fe02-4f78-a742-b5bc35f8b61e
