### PR TITLE
fix(bn-listbox): change options position on scroll

### DIFF
--- a/src/components/BnListbox/BnListbox.vue
+++ b/src/components/BnListbox/BnListbox.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RuleExpression, useField } from 'vee-validate';
-import { ref, ComponentPublicInstance, watchEffect, computed, toRefs } from 'vue';
+import { ref, ComponentPublicInstance, watch, computed, toRefs } from 'vue';
 import { useElementBounding } from '@vueuse/core';
 import {
   Listbox,
@@ -122,11 +122,18 @@ const { handleChange, value, meta, setTouched, errorMessage } = useField<InputVa
 });
 
 const listboxButtonRef = ref<ComponentPublicInstance>();
-const { width: listboxButtonWidth } = useElementBounding(listboxButtonRef);
+const {
+  width: listboxButtonWidth, top: listboxButtonTop, left: listboxButtonLeft,
+} = useElementBounding(listboxButtonRef);
 
 const listboxOptionsRef = ref<ComponentPublicInstance>();
 const LISTBOX_OFFSET = 4;
-watchEffect(() => {
+const buttonPositionAndOptionsPresenceForWatchDependencies = computed(() => ([
+  listboxButtonTop.value,
+  listboxButtonLeft.value,
+  listboxOptionsRef.value?.$el,
+]));
+watch(buttonPositionAndOptionsPresenceForWatchDependencies, () => {
   if (listboxOptionsRef.value && listboxOptionsRef.value.$el && listboxButtonRef.value) {
     computePosition(
       listboxButtonRef.value.$el,


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects

## Changes

When having a listbox options' open, and then scrolling, a bug was ocurring that made the options box not move with the select and stay fixed in the screen:

https://github.com/platanus/banano/assets/12057523/05b39dd0-87e3-4aec-98ee-8597374162f9

This PR fixes that issue. The options box is teleported to the body to avoid issues with z-index and overflow, and it's position was being updated using a `watchEffect`. This watcher wasn't detecting the changes in position in `listboxButtonRef.value.$el`, so it wasn't running on scroll. To fix the issue, we are changing it to use a regular `watch` with explicit dependencies, where we are including top and left values returned by `useElementBounding`. With this, is now working as expected:

https://github.com/platanus/banano/assets/12057523/d62d86df-64b8-4edb-9a35-e83c2bd50ea3
