### PR TITLE
Datepicker example

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@vitejs/plugin-vue": "^4.2.3",
     "@vue/eslint-config-typescript": "^10.0.0",
     "@vue/test-utils": "^2.4.0",
+    "@vuepic/vue-datepicker": "^5.4.0",
     "autoprefixer": "^10.4.4",
     "eslint": "^8.13.0",
     "eslint-plugin-import": "^2.26.0",

--- a/src/components/BnInput/BnInput.story.vue
+++ b/src/components/BnInput/BnInput.story.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { GenericValidateFunction } from 'vee-validate';
+import VueDatePicker from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
 import { reactive } from 'vue';
 import BnInput from './BnInput.vue';
 
@@ -8,6 +10,7 @@ const state = reactive({
   emptyValue: undefined,
   validate: undefined,
   validateCustom: undefined,
+  date: new Date(),
 });
 
 /* eslint-disable max-len, vue/max-len */
@@ -201,6 +204,52 @@ function isRequired(val: string) {
         </BnInput>
       </template>
     </Variant>
+    <Variant
+      title="with @vuepic/vue-datepicker datepicker"
+    >
+      <template #default>
+        <VueDatePicker
+          v-model="state.date"
+          text-input
+        >
+          <template #dp-input="{ value, onInput, onEnter, onTab, onBlur, onKeypress, onPaste }">
+            <BnInput
+              :model-value="value"
+              name="datepicker"
+              autocomplete="off"
+              @update:model-value="onInput"
+              @keydown.enter="onEnter"
+              @keydown.tab="onTab"
+              @blur="onBlur"
+              @keypress="onKeypress"
+              @paste="onPaste"
+            />
+          </template>
+        </VueDatePicker>
+      </template>
+      <template #source>
+        <textarea v-pre>
+          <VueDatePicker
+            v-model="state.date"
+            text-input
+          >
+            <template #dp-input="{ value, onInput, onEnter, onTab, onBlur, onKeypress, onPaste }">
+              <BnInput
+                :model-value="value"
+                name="datepicker"
+                autocomplete="off"
+                @update:model-value="onInput"
+                @keydown.enter="onEnter"
+                @keydown.tab="onTab"
+                @blur="onBlur"
+                @keypress="onKeypress"
+                @paste="onPaste"
+              />
+            </template>
+          </VueDatePicker>
+        </textarea>
+      </template>
+    </Variant>
   </Story>
 </template>
 
@@ -208,4 +257,7 @@ function isRequired(val: string) {
   .__histoire-sandbox {
     padding: 10px;
   }
-  </style>
+  .__histoire-render-story:not(.__histoire-render-custom-controls) {
+    overflow: visible;
+  }
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,6 +169,13 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.5.tgz#721fd042f3ce1896238cf1b341c77eb7dee7dbea"
   integrity sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==
 
+"@babel/runtime@^7.21.0":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@codemirror/commands@^6.1.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.2.1.tgz#ab5e979ad1458bbe395bf69ac601f461ac73cf08"
@@ -1226,6 +1233,14 @@
     "@volar/typescript" "1.7.10"
     "@vue/language-core" "1.8.3"
 
+"@vuepic/vue-datepicker@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@vuepic/vue-datepicker/-/vue-datepicker-5.4.0.tgz#932706e2882167dc7f51c4cca833428c172ddd44"
+  integrity sha512-9f1ZqRDfak/UmBbD81BdqMDpUku2YphTwQXG8DF6hsrjIXsq5sX7BWJB6LhyVgvX9QFrSyFIp4fsHE3UFofZ7A==
+  dependencies:
+    date-fns "^2.30.0"
+    date-fns-tz "^1.3.7"
+
 "@vueuse/core@10.2.1", "@vueuse/core@^10.1.0", "@vueuse/core@^10.2.1":
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.2.1.tgz#a62b54cdaf1496138a9f8a7df7f9d644892b421f"
@@ -1767,6 +1782,18 @@ data-urls@^3.0.2:
     abab "^2.0.6"
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
+
+date-fns-tz@^1.3.7:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.8.tgz#083e3a4e1f19b7857fa0c18deea6c2bc46ded7b9"
+  integrity sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==
+
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -3893,6 +3920,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects

## Changes

This PR adds an example of a datepicker input using `@vuepic/vue-datepicker` library to the `BnInput` stories. Couple of things to note:
- For the example I used a text-input datepicker, so it works changing dates with the datepicker or via text input
- I had to add som css targeting histoire elements, the datepicker was being hidden
- I added a `#source` slot to the variant, because the auto generated source wasn't any good.
  | Auto generated  | With #source slot |
  | ------------- | ------------- |
  | ![image](https://github.com/platanus/banano/assets/12057523/990d1461-3416-43d0-a569-9b0c587b000b)  | ![image](https://github.com/platanus/banano/assets/12057523/c384416b-19f5-4f65-ab87-d6f793eea322)  |

https://github.com/platanus/banano/assets/12057523/4a1b91ee-313a-483b-8345-bdba10f42338
