### PR TITLE
Feat/npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,32 @@
+name: Publish Package to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn vitest
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPMJS_ACCESS_TOKEN}}

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright 2021 PLATANUS SPA
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ Since TypeScript cannot handle type information for `.vue` imports, they are shi
 2. Reload the VS Code window by running `Developer: Reload Window` from the command palette.
 
 You can learn more about Take Over mode [here](https://github.com/johnsoncodehk/volar/discussions/471).
+
+## Credits
+
+Thank you [contributors](https://github.com/platanus/banano/graphs/contributors)!
+
+<img src="http://platan.us/gravatar_with_text.png" alt="Platanus" width="250"/>
+
+banano is maintained by [platanus](http://platan.us).
+
+## License
+
+Banano is © 2021 Platanus, spa. It is free software and may be redistributed under the terms specified in the LICENSE file.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,32 @@
 {
-  "name": "banano",
+  "name": "@platanus/banano",
   "private": false,
-  "version": "0.0.0",
+  "version": "1.0.1",
+  "description": "A Vue 3 UI components library for platanus proyects",
+  "main": "./dist/vue/index.js",
+  "module": "./dist/vue/index.js",
+  "types": "./dist/vue/index.d.ts",
+  "author": "Platanus",
+  "license": "MIT",
+  "repository": "https://github.com/platanus/banano.git",
+  "exports": {
+    ".": "./dist/vue/index.js",
+    "./tailwind": "./dist/tailwind/tailwind.umd.cjs"
+  },
+  "bin": {
+    "banano": "./bin/banano.js"
+  },
+  "contributors": [
+    {
+      "name": "Diego Fernández"
+    },
+    {
+      "name": "Guillermo Moreno"
+    },
+    {
+      "name": "Francisca Rebolledo"
+    }
+  ],
   "scripts": {
     "dev": "vite",
     "build": "vite build && vite build --config vite.tailwind.config.ts",
@@ -29,16 +54,6 @@
     "vee-validate": "^4.6.9",
     "vue": "^3.3.4"
   },
-  "main": "./dist/vue/index.js",
-  "module": "./dist/vue/index.js",
-  "exports": {
-    ".": "./dist/vue/index.js",
-    "./tailwind": "./dist/tailwind/tailwind.umd.cjs"
-  },
-  "bin": {
-    "banano": "./bin/banano.js"
-  },
-  "types": "./dist/vue/index.d.ts",
   "devDependencies": {
     "@headlessui/tailwindcss": "^0.1.1",
     "@histoire/plugin-vue": "^0.15.8",


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects


## Changes

This PR adds some configuration to publish on npm. It adds info to package.json and also adds a file to automatize publish with github actions.