### PR TITLE
feat(bn-file-input): change default style

### DIFF
--- a/src/components/BnBtn/BnBtn.styles.cjs
+++ b/src/components/BnBtn/BnBtn.styles.cjs
@@ -35,7 +35,7 @@ module.exports = {
       '@apply rounded-full': {},
     },
     '&--shapes-rounded': {
-      '@apply rounded-lg': {},
+      '@apply rounded': {},
     },
     '&--variants-default': {
       '@apply border border-solid': {},

--- a/src/components/BnFileInput/BnFileInput.styles.cjs
+++ b/src/components/BnFileInput/BnFileInput.styles.cjs
@@ -2,7 +2,7 @@ module.exports = {
   '.bn-file-input': {
     '&__wrapper': {
       '&--variants-default': {
-        '@apply form-input flex h-12 w-full items-center rounded-lg border border-gray-200 px-3 py-2 bg-banano-bg': {},
+        '@apply form-input flex h-12 w-full items-center rounded-lg border border-gray-100 px-3 py-2 bg-banano-bg': {},
       },
       '&--disabled': {
         '@apply bg-gray-100 opacity-75 cursor-not-allowed': {},
@@ -18,7 +18,7 @@ module.exports = {
       '@apply hidden': {},
     },
     '&__button': {
-      '@apply mr-2 shrink-0 cursor-pointer outline-none': {},
+      '@apply ml-2 shrink-0 cursor-pointer outline-none': {},
     },
     '&__label': {
       '@apply w-full overflow-hidden text-sm text-banano-text-foreground': {},

--- a/src/components/BnFileInput/BnFileInput.styles.cjs
+++ b/src/components/BnFileInput/BnFileInput.styles.cjs
@@ -24,7 +24,7 @@ module.exports = {
       '@apply w-full overflow-hidden text-sm text-banano-text-foreground': {},
     },
     '&__file-list': {
-      '@apply flex w-full items-center': {},
+      '@apply flex w-0 min-w-full max-w-full items-center': {},
     },
     '&__file-names': {
       '@apply truncate': {},

--- a/src/components/BnFileInput/BnFileInput.vue
+++ b/src/components/BnFileInput/BnFileInput.vue
@@ -206,20 +206,6 @@ function blur(event: Event) {
         :add-file="addFile"
         :value="inputValue"
       >
-        <template v-if="variant === 'default'">
-          <BnBtn
-            size="xs"
-            type="button"
-            class="bn-file-input__button"
-            :class="props.classes.button"
-            variant="outline"
-            :disabled="props.disabled"
-            tabindex="-1"
-            @click="openFileDialog"
-          >
-            {{ props.buttonText }}
-          </BnBtn>
-        </template>
         <template v-if="isAvatar">
           <button
             type="button"
@@ -281,6 +267,21 @@ function blur(event: Event) {
             {{ props.placeholder }}
           </span>
         </div>
+        <template v-if="variant === 'default'">
+          <BnBtn
+            size="xs"
+            type="button"
+            shape="rounded"
+            class="bn-file-input__button"
+            :class="props.classes.button"
+            variant="outline"
+            :disabled="props.disabled"
+            tabindex="-1"
+            @click="openFileDialog"
+          >
+            {{ props.buttonText }}
+          </BnBtn>
+        </template>
       </slot>
     </component>
     <slot


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects.
- The file input component had a provisional style.


## Changes
- The style has been updated, moving the button to the right and making the border slightly lighter.
- At some point the component stopped being able to truncate filenames, overflowing its parent. A fix is added to make flex work with text truncation.
- BnBtn `rounded` variant is reduced slightly to fit style.

Before:
![image](https://github.com/platanus/banano/assets/472791/9fd17e35-66be-46f5-bcd6-8d9a20cec2fc)

After:
![image](https://github.com/platanus/banano/assets/472791/f81367c6-5743-42bb-81c7-825a70aa2e75)

