### PR TITLE
fix(bn-listbox): add z-index to listbox options

### DIFF
--- a/src/components/BnListbox/BnListbox.styles.cjs
+++ b/src/components/BnListbox/BnListbox.styles.cjs
@@ -42,7 +42,8 @@ module.exports = {
     '@apply fixed max-h-60 w-full overflow-auto rounded-lg border border-gray-200 bg-white': {},
     '@apply z-bn-listbox-options': {},
     '&__option': {
-      '@apply flex h-12 items-center p-3 ui-selected:text-white hover:text-white ui-active:text-white': {},
+      '@apply flex h-12 items-center p-3 text-banano-text-foreground': {},
+      '@apply ui-selected:text-white hover:text-white ui-active:text-white': {},
       colors: {
         '@apply hover:bg-varColor-600 ui-selected:bg-varColor-600 ui-active:bg-varColor-600': {},
       },

--- a/src/components/BnListbox/BnListbox.styles.cjs
+++ b/src/components/BnListbox/BnListbox.styles.cjs
@@ -40,6 +40,7 @@ module.exports = {
   // Separate class since it's teleported to body
   '.bn-listbox-options': {
     '@apply fixed max-h-60 w-full overflow-auto rounded-lg border border-gray-200 bg-white': {},
+    '@apply z-bn-listbox-options': {},
     '&__option': {
       '@apply flex h-12 items-center p-3 ui-selected:text-white hover:text-white ui-active:text-white': {},
       colors: {

--- a/src/tailwind/index.cjs
+++ b/src/tailwind/index.cjs
@@ -141,6 +141,9 @@ module.exports = plugin.withOptions(
     return {
       theme: {
         extend: {
+          zIndex: {
+            'bn-listbox-options': 1025,
+          },
           colors: themeColors,
         },
       },


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects

## Changes

- Adds a default z-index value for the listbox options. Select 2 uses `1025` so that's the default but it should be able to be overridden.
- Adds default text color to the options.

Before:
![image](https://github.com/platanus/banano/assets/472791/4e20de89-d046-444c-ad46-1c295a4785ac)

After:
![image](https://github.com/platanus/banano/assets/472791/302511d0-b27d-4883-8399-1b4256638b31)


