### PR TITLE
feat(docs): add documentation for color prop and how to add colors

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -24,12 +24,12 @@ export default defineConfig({
               collapsed: false,
               items: [
                 {
-                  text: 'Classes and Components',
-                  link: '/classes-and-components',
-                },
-                {
                   text: 'Colors',
                   link: '/colors',
+                },
+                {
+                  text: 'Classes and Components',
+                  link: '/classes-and-components',
                 },
               ],
             },

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,5 +1,61 @@
 # Colors
 
+## Color Prop
+
+Most components in this library have a `color` prop that can be used to change either the main color or the color accent of the component, however it requires a bit of setup before it can be used due to the way Tailwind works.
+
+### Setup
+
+To use the `color` prop, you need to configure the library to include the colors you want to use. This is done by passing an object to the `require('banano/tailwind')` function, with a `colors` property that is an array of the colors you want to include. For example, to include the `lime` color, you would do the following:
+
+```js
+// tailwind.config.js
+{
+  ...
+  require('banano/tailwind')({ colors: ['lime']}),
+}
+```
+
+The colors that can be included can be found in the [Tailwind Colors](https://tailwindcss.com/docs/customizing-colors#color-palette-reference) palette, plus any custom color added in the Tailwind config file. However, the custom colors need to have all their variants defined (100, 200, 300...)
+, otherwise the `color` prop will not work. For example, if you add a custom color like this it will not work:
+
+```js
+// tailwind.config.js
+{
+  ...
+  theme: {
+    extend: {
+      colors: {
+        custom: '#ff0000',
+      },
+    },
+  },
+}
+```
+
+But if you add it like this, it will work:
+
+```js
+// tailwind.config.js
+{
+  ...
+  theme: {
+    extend: {
+      colors: {
+        custom: {
+          100: '#ff0000',
+          200: '#ff0011',
+          300: '#ff0022',
+          // ...
+        },
+      },
+    },
+  },
+}
+```
+
+## Theme Colors
+
 Banano extends the theme to include some custom colors that affect some components across this library. These colors can be overriden in your projects `tailwind.config.js` file. Some of these colors require a **object** of colors with their numbered variants, for example, `tailwindColors.purple`, and some require a **single string** color, for example `tailwindColors.purple['100']`.
 The colors are as follows:
 

--- a/docs/components/bn-btn.md
+++ b/docs/components/bn-btn.md
@@ -116,15 +116,9 @@ You can change the color of the button using the `color` prop.
   </div>
 </code-preview>
 
-Note: the `color` prop only supports the included colors when configuring the library.
-
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
 
 ## Slots
 

--- a/docs/components/bn-checkbox.md
+++ b/docs/components/bn-checkbox.md
@@ -156,15 +156,9 @@ You can change the color accent of the checkbox using the `color` prop.
   </div>
 </code-preview>
 
-Note: the color prop only supports the included colors when configuring the library.
-
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
 
 ## Slots
 

--- a/docs/components/bn-file-input.md
+++ b/docs/components/bn-file-input.md
@@ -172,15 +172,11 @@ You can change the color accent of the default variants of the file input using 
   </div>
 </code-preview>
 
-Note: the color prop only supports the included colors when configuring the library.
 
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
+
 
 ## Slots
 

--- a/docs/components/bn-input.md
+++ b/docs/components/bn-input.md
@@ -134,15 +134,9 @@ You can change the color accent of the input using the `color` prop.
   </div>
 </code-preview>
 
-Note: the color prop only supports the included colors when configuring the library.
-
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
 
 ## Slots
 

--- a/docs/components/bn-listbox.md
+++ b/docs/components/bn-listbox.md
@@ -196,15 +196,9 @@ You can change the color accent of the listbox using the `color` prop.
   />
 </code-preview>
 
-Note: the color prop only supports the included colors when configuring the library.
-
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
 
 ## Slots
 

--- a/docs/components/bn-pagination.md
+++ b/docs/components/bn-pagination.md
@@ -99,15 +99,7 @@ function handlePageChange(newPage) {
 
 ## Colors
 
-Due to the way Tailwind compiles classes, to avoid generating CSS for every single color it includes, Banano only has access to the colors you define in its configuration:
-
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+You can change the color of the pagination buttons using the `color` prop.
 
 ```html
 <bn-pagination
@@ -120,6 +112,10 @@ Due to the way Tailwind compiles classes, to avoid generating CSS for every sing
 <code-preview>
   <bn-pagination :total-pages="20" :current-page="currentPage" color="lime" />
 </code-preview>
+
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
 
 ## Customization
 

--- a/docs/components/bn-textarea.md
+++ b/docs/components/bn-textarea.md
@@ -127,15 +127,11 @@ You can change the color accent of the textarea using the `color` prop.
   </div>
 </code-preview>
 
-Note: the color prop only supports the included colors when configuring the library.
 
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
+
 
 ## Slots
 

--- a/docs/components/bn-toggle.md
+++ b/docs/components/bn-toggle.md
@@ -51,15 +51,9 @@ You can change the color accent of the toggle using the `color` prop.
   </div>
 </code-preview>
 
-Note: the color prop only supports the included colors when configuring the library.
-
-```javascript
-// tailwind.config.js
-{
-...
-  require('banano/tailwind')({ colors: ['lime']}),
-}
-```
+::: tip
+The `color` prop only supports the colors set when configuring the library. See [Colors](../colors.md) for more information.
+:::
 
 ## Slots
 


### PR DESCRIPTION
## Context

- Banano is a component library for use in platanus projects
- Most components have a `color` prop

## Changes
Adds documentation for how to add colors so they are available for use when using the `color` prop.
